### PR TITLE
Add production genmedia skill bundles

### DIFF
--- a/skills/character-design/SKILL.md
+++ b/skills/character-design/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: character-design
+description: >
+  Build consistent character designs and character media with genmedia. Use
+  this for original characters, reference sheets, expression sheets, outfit
+  variations, identity-preserving edits, and character-to-video workflows.
+---
+
+# Character design with genmedia
+
+Use this skill when the user wants to create, refine, or preserve a character.
+Load the reference files when needed:
+
+- `references/anchor-system.md`
+- `references/prompt-patterns.md`
+- `references/examples.md`
+
+Load `model-routing` alongside this skill for default endpoint choices.
+
+The main objective is consistency. Keep the character anchor stable and change
+only the requested scene, expression, outfit, camera, or action.
+
+## Inputs to collect
+
+Only ask for missing inputs that affect identity or model routing.
+
+- Character type: realistic human, stylized, anime, mascot, fantasy, sci-fi.
+- Identity anchor: age range, face shape, hair, eyes, build, posture, marks.
+- Style: photographic, 3D, illustration, manga, comic, game concept art.
+- Needed outputs: portrait, full body, turnaround, expression sheet, outfit
+  set, action still, video shot, edit of an existing character.
+- References: source image, approved design, costume, pose, style board.
+- Consistency level: exploratory, pitch-ready, production continuity.
+- Model preference: use `model-routing` defaults unless the user names a model
+  or the job needs a quality/cost tradeoff decision.
+
+## Genmedia workflow
+
+1. Start from routed endpoint IDs.
+
+   ```bash
+   genmedia models --endpoint_id openai/gpt-image-2 --json
+   genmedia models --endpoint_id fal-ai/nano-banana-pro/edit --json
+   genmedia models --endpoint_id bytedance/seedance-2.0/image-to-video --json
+   genmedia models --endpoint_id veed/fabric-1.0 --json
+   ```
+
+   Use text search only as fallback discovery for an unsupported role:
+
+   ```bash
+   genmedia docs "consistent character generation" --json
+   genmedia models "image editing character consistency" --json
+   ```
+
+2. Inspect schema before each endpoint run.
+
+   ```bash
+   genmedia schema <endpoint_id> --json
+   genmedia pricing <endpoint_id> --json
+   ```
+
+3. Upload references.
+
+   ```bash
+   genmedia upload ./character-reference.png --json
+   genmedia upload ./costume-reference.png --json
+   ```
+
+4. Run stills or sheets with download.
+
+   ```bash
+   genmedia run <endpoint_id> \
+     --prompt "<anchor + variable prompt>" \
+     --image_url "<reference url if supported>" \
+     --download "./outputs/characters/{request_id}_{index}.{ext}" \
+     --json
+   ```
+
+5. Run video async.
+
+   ```bash
+   genmedia run <endpoint_id> \
+     --prompt "<anchor + shot action>" \
+     --image_url "<approved character frame if supported>" \
+     --async \
+     --json
+
+   genmedia status <endpoint_id> <request_id> \
+     --download "./outputs/characters/{request_id}_{index}.{ext}" \
+     --json
+   ```
+
+Use only schema-supported fields. If the model supports seed, reference image,
+image strength, multiple image inputs, or negative prompt, use them deliberately
+and record what was used.
+
+## Character anchor
+
+Create a short immutable anchor before generating.
+
+```text
+CHARACTER ANCHOR:
+[name or codename], [age range], [face shape], [eye shape and color],
+[nose and lips], [skin tone and distinguishing marks], [hair color, texture,
+style], [body build and posture], [signature clothing or silhouette],
+[style target]
+```
+
+Then add a variable block for the current shot.
+
+```text
+SHOT VARIABLE:
+[expression], [pose/action], [outfit changes if allowed], [environment],
+[camera/framing], [lighting], [mood]
+```
+
+Never rewrite the anchor casually. If a result changes identity, strengthen the
+anchor or switch to a reference/edit workflow instead of adding more style
+words.
+
+## Model routing
+
+- New character concept with maximum consistency: use `openai/gpt-image-2`.
+- Premium but cheaper image option: use `fal-ai/nano-banana-pro` or
+  `fal-ai/nano-banana-2`.
+- Fast exploratory drafts: use `fal-ai/flux-2/klein/9b`.
+- Consistent sheet from an approved character: use `openai/gpt-image-2` first;
+  if editing an existing image, inspect `openai/gpt-image-2/edit`.
+- Outfit variations and character edits: use `fal-ai/nano-banana-pro/edit`,
+  then `openai/gpt-image-2/edit`, then
+  `fal-ai/bytedance/seedream/v5/lite/edit`.
+- Expression sheet: one approved face reference, multiple controlled
+  expression prompts.
+- Character video: approved still frame first, then
+  `bytedance/seedance-2.0/image-to-video` for final quality.
+- Fast video drafts: use `xai/grok-imagine-video/image-to-video`.
+- Talking avatar or lip-sync: use `veed/fabric-1.0`,
+  `veed/fabric-1.0/text`, or `fal-ai/creatify/aurora`.
+
+## Quality bar
+
+Reject or retry when:
+
+- Face shape, eye spacing, hairstyle, marks, or body build drift.
+- Outfit changes when the prompt says only expression or pose should change.
+- The sheet mixes styles across panels.
+- Hands or props distract from the requested design task.
+- Video motion changes age, face, costume, or silhouette.
+
+Return downloaded paths and include the anchor used so future prompts can reuse
+the same identity.

--- a/skills/character-design/references/anchor-system.md
+++ b/skills/character-design/references/anchor-system.md
@@ -1,0 +1,65 @@
+# Character anchor system
+
+The anchor is the identity contract. Keep it compact and repeat it in every
+prompt that should preserve the same character.
+
+## Anchor fields
+
+- Codename: use a neutral name if the user has not named the character.
+- Age range: avoid exact age unless supplied.
+- Face: shape, cheekbones, jawline, chin.
+- Eyes: shape, spacing, eyelids, color, brows.
+- Nose and mouth: bridge, tip, lip shape, smile line.
+- Skin: tone, freckles, scars, moles, texture.
+- Hair: color, length, texture, part, silhouette.
+- Build: height impression, shoulders, posture, proportions.
+- Signature: clothing silhouette, accessory, color accent, symbolic prop.
+- Style: photoreal, anime, painterly, 3D, comic, game concept art.
+
+## Immutable anchor template
+
+```text
+CHARACTER ANCHOR:
+[codename], [age range], [gender presentation if relevant], [face shape],
+[eye shape and color], [brow shape], [nose], [mouth], [skin details],
+[hair color, length, texture, and style], [build and posture],
+[signature wardrobe or accessory], [visual style]
+```
+
+## Variable template
+
+```text
+SHOT VARIABLE:
+[expression], [pose/action], [outfit allowed to change or not], [setting],
+[camera distance and angle], [lighting], [mood], [output format]
+```
+
+## What can change
+
+- Expression
+- Pose
+- Camera angle
+- Lighting
+- Setting
+- Outfit, only if requested
+- Time period, only if requested
+- Medium, only if requested
+
+## What should not drift
+
+- Eye spacing and shape
+- Face silhouette
+- Nose and lip structure
+- Hair silhouette
+- Skin marks
+- Body proportions
+- Signature accessory
+- Overall style target
+
+## Consistency escalation
+
+1. Text-only anchor for exploration.
+2. Approved image reference for continuity.
+3. Edit or reference-image workflow for outfit and expression variations.
+4. Image-to-video from an approved still for motion.
+5. User-selected identity-preserving endpoint for production series.

--- a/skills/character-design/references/examples.md
+++ b/skills/character-design/references/examples.md
@@ -1,0 +1,56 @@
+# Character examples
+
+Use these as quality references and rewrite them for the user's actual
+character. Keep anchors shorter than the examples when possible.
+
+## Realistic editorial character
+
+```text
+CHARACTER ANCHOR:
+Maren, woman in her early 30s, oval face with high cheekbones, almond green
+eyes, straight nose, soft defined lips, light olive skin with a small mole
+under the left eye, dark auburn shoulder-length wavy hair with a center part,
+slim athletic build, upright calm posture, charcoal wool coat and small silver
+ear cuff, realistic cinematic photography
+
+SHOT VARIABLE:
+waist-up portrait in a quiet train station at blue hour, thoughtful expression,
+three-quarter angle, soft practical lights behind her, shallow depth of field,
+35mm documentary lens feel, no extra people in focus
+```
+
+## Stylized sci-fi pilot
+
+```text
+CHARACTER ANCHOR:
+Kade, young adult male sci-fi pilot, square face, heavy brows, narrow dark
+brown eyes, short black textured hair, warm brown skin, compact muscular
+build, matte white flight jacket with orange collar stripe, small triangular
+mission patch on left chest, high-end animated feature style
+
+SHOT VARIABLE:
+full-body design sheet, front view, helmet tucked under one arm, neutral gray
+background, clean readable silhouette, precise costume seams, no extra logos
+```
+
+## Mascot concept
+
+```text
+CHARACTER ANCHOR:
+round friendly tea-shop mascot, small fox-like creature with cream fur, amber
+ears, oversized green scarf, tiny ceramic cup pendant, soft plush proportions,
+warm illustrated brand mascot style
+
+SHOT VARIABLE:
+three-quarter standing pose, waving with one paw, simple mint background,
+clear silhouette, cheerful but not childish, no text, no extra mascots
+```
+
+## Outfit-only edit
+
+```text
+keep the uploaded character's face, hairstyle, skin tone, body proportions,
+and illustration style exactly the same; change only the outfit to a navy
+raincoat over a cream sweater, wet street lighting, same identity, no face
+changes, no age changes, no additional characters
+```

--- a/skills/character-design/references/prompt-patterns.md
+++ b/skills/character-design/references/prompt-patterns.md
@@ -1,0 +1,74 @@
+# Character prompt patterns
+
+## First concept portrait
+
+```text
+CHARACTER ANCHOR:
+[anchor]
+
+SHOT VARIABLE:
+waist-up portrait, neutral expression, relaxed posture, simple background,
+[lighting], [style], clean readable design, no extra characters
+```
+
+## Full-body design
+
+```text
+CHARACTER ANCHOR:
+[anchor]
+
+SHOT VARIABLE:
+full-body character design standing pose, entire silhouette visible, costume
+details clear, simple neutral background, front view, production concept art,
+no cropped feet, no extra props unless requested
+```
+
+## Turnaround sheet
+
+```text
+CHARACTER ANCHOR:
+[anchor]
+
+SHOT VARIABLE:
+character turnaround sheet with front view, side view, back view, consistent
+proportions and outfit, neutral standing pose, clean white background,
+production model sheet layout, no style drift between views
+```
+
+## Expression sheet
+
+```text
+CHARACTER ANCHOR:
+[anchor]
+
+SHOT VARIABLE:
+expression sheet with nine head-and-shoulder portraits: neutral, happy,
+angry, afraid, sad, surprised, suspicious, determined, amused; same face,
+same hairstyle, same style, clean grid, no identity drift
+```
+
+## Outfit variation
+
+```text
+keep the uploaded character's face, hair, body proportions, and style exactly
+consistent; change only the outfit to [outfit], [material and color], same
+pose or simple standing pose, clean studio background, no face changes
+```
+
+## Character video shot
+
+```text
+[duration] second shot of the uploaded character, same face, hair, outfit, and
+body proportions, [specific action], [camera movement], [environment],
+[lighting], controlled motion, no age drift, no costume morphing
+```
+
+## Negative prompt components
+
+Use only when supported by schema:
+
+```text
+different face, different hairstyle, different eye color, altered age,
+changed outfit, extra character, distorted hands, inconsistent style, cropped
+body, duplicate character, text, watermark
+```

--- a/skills/cinematography/SKILL.md
+++ b/skills/cinematography/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: cinematography
+description: >
+  Design cinematic image and video prompts for genmedia. Use this for shot
+  language, camera movement, lighting, lens choices, color grade, film texture,
+  scene blocking, and production-ready visual direction.
+---
+
+# Cinematography with genmedia
+
+Use this skill when the user needs cinematic direction, not generic "make it
+cinematic" prompting. Load references as needed:
+
+- `references/shot-language.md`
+- `references/lighting-lens-color.md`
+- `references/examples.md`
+
+Load `model-routing` alongside this skill for default endpoint choices.
+
+Write concrete visual direction. Avoid empty prestige words and em dashes.
+
+## Inputs to collect
+
+Ask only for what affects the shot:
+
+- Subject and action.
+- Medium: still image, video, image-to-video, edit, storyboard frame.
+- Genre and mood.
+- Framing: close-up, medium, wide, overhead, POV, profile, locked-off.
+- Camera motion for video: push-in, dolly, tracking, handheld, crane, drone.
+- Lens feel: wide, normal, telephoto, macro, shallow or deep focus.
+- Lighting: natural, practical, studio, noir, high key, low key, backlit.
+- Output: aspect ratio, duration, first frame, last frame, download path.
+- Preferred model, if the user wants a specific cinematography model or
+  quality/cost profile.
+
+## Genmedia workflow
+
+1. Start from routed endpoint IDs.
+
+   ```bash
+   genmedia models --endpoint_id openai/gpt-image-2 --json
+   genmedia models --endpoint_id fal-ai/nano-banana-pro --json
+   genmedia models --endpoint_id bytedance/seedance-2.0/text-to-video --json
+   genmedia models --endpoint_id bytedance/seedance-2.0/image-to-video --json
+   genmedia models --endpoint_id xai/grok-imagine-video/text-to-video --json
+   ```
+
+   Use text search only as fallback discovery for a missing camera-control
+   role:
+
+   ```bash
+   genmedia models "cinematic video generation camera movement" --json
+   genmedia docs "video generation camera movement prompt" --json
+   ```
+
+2. Inspect schema and use only supported controls.
+
+   ```bash
+   genmedia schema <endpoint_id> --json
+   genmedia pricing <endpoint_id> --json
+   ```
+
+3. Upload references when using image-to-video, first frame, last frame, style
+   reference, or character/product continuity.
+
+   ```bash
+   genmedia upload ./frame.png --json
+   ```
+
+4. Run stills with direct download.
+
+   ```bash
+   genmedia run <endpoint_id> \
+     --prompt "<cinematography prompt>" \
+     --download "./outputs/cinema/{request_id}_{index}.{ext}" \
+     --json
+   ```
+
+5. Run video async.
+
+   ```bash
+   genmedia run <endpoint_id> \
+     --prompt "<shot prompt>" \
+     --image_url "<uploaded frame if supported>" \
+     --async \
+     --json
+
+   genmedia status <endpoint_id> <request_id> \
+     --download "./outputs/cinema/{request_id}_{index}.{ext}" \
+     --json
+   ```
+
+## Prompt build order
+
+Use the SCLCAM structure:
+
+1. Subject: who or what is in frame.
+2. Context: location, time, weather, story moment.
+3. Lens/framing: distance, angle, focal length feel, depth of field.
+4. Camera motion: only for video or if motion blur is desired.
+5. Atmosphere: haze, rain, practicals, reflections, texture.
+6. Mood/color: palette, contrast, grade, exposure style.
+7. Output controls: aspect ratio, duration, first-frame continuity.
+
+Example structure:
+
+```text
+[subject] in [context], framed as [shot size and angle], [lens feel],
+[lighting setup], [camera movement if video], [color grade], [texture],
+[duration or aspect ratio], [continuity constraints]
+```
+
+## Model routing
+
+- Premium realistic still: use `openai/gpt-image-2`.
+- Premium stylized still: use `openai/gpt-image-2`, then
+  `fal-ai/nano-banana-pro`, then `fal-ai/nano-banana-2`.
+- Fast draft still: use `fal-ai/flux-2/klein/9b`.
+- Highest quality video: use `bytedance/seedance-2.0/text-to-video` or
+  `bytedance/seedance-2.0/image-to-video`.
+- Motion from a strong frame: use `bytedance/seedance-2.0/image-to-video`.
+- Fast or lower-cost video: use `xai/grok-imagine-video/text-to-video` or
+  `xai/grok-imagine-video/image-to-video`.
+- Complex camera language: inspect Seedance 2.0 first, then Kling v3 when
+  multi-prompt or element controls matter.
+- Story sequence: use the storytelling skill with this skill as shot-language
+  support.
+- Character or product continuity: use the relevant domain skill first, then
+  apply cinematography as the variable block.
+
+## Quality bar
+
+Before returning, check:
+
+- Camera movement is physically plausible for the scene.
+- Lens, shot size, and camera angle do not contradict each other.
+- Lighting direction is clear and consistent.
+- Color grade supports the mood without flattening subject detail.
+- Video prompt describes one shot unless the selected model supports multiple
+  prompts or shot lists.
+- Downloaded files come from `downloaded_files[]`.
+
+If a result looks generic, improve specificity in camera, blocking, light, and
+environment before adding more adjectives.

--- a/skills/cinematography/references/examples.md
+++ b/skills/cinematography/references/examples.md
@@ -1,0 +1,49 @@
+# Cinematography examples
+
+Use these as direction patterns. Replace subject, model fields, and output
+controls with the current task.
+
+## Noir close-up
+
+```text
+a detective sitting alone in a parked car at night, close-up from passenger
+seat angle, 50mm lens feel, rain streaks on the window in foreground, hard
+streetlight slashes across his face, low key noir lighting, deep shadows,
+muted green and amber grade, still frame, no text
+```
+
+## Product macro glide
+
+```text
+single continuous macro glide across the brushed steel edge of a luxury watch,
+100mm macro lens feel, black velvet surface, thin strip light reflected along
+the bevel, shallow depth of field, slow controlled camera movement, clean dark
+commercial grade, no extra text, no logo distortion
+```
+
+## Sci-fi wide shot
+
+```text
+small astronaut crossing a vast white salt flat toward a black monolith,
+extreme wide shot, low horizon, 24mm lens feel, late afternoon backlight,
+long shadow, minimal composition, cool silver color grade, quiet atmospheric
+haze, cinematic still, no extra ships
+```
+
+## Handheld pursuit
+
+```text
+8 second handheld tracking shot following a woman running through a narrow
+market alley at night, camera shoulder-height behind her, practical neon and
+food stall lights, motion blur on background, subject remains readable,
+urgent thriller pacing, one continuous shot, no cuts
+```
+
+## Warm interior drama
+
+```text
+two siblings at a kitchen table after midnight, medium-wide static frame,
+35mm lens feel, warm practical lamp on table, cool moonlight through window,
+subtle haze, quiet tension, naturalistic color grade, deep focus enough to
+read both faces, no melodramatic poses
+```

--- a/skills/cinematography/references/lighting-lens-color.md
+++ b/skills/cinematography/references/lighting-lens-color.md
@@ -1,0 +1,49 @@
+# Lighting, lens, and color reference
+
+## Lighting setups
+
+- Soft key: flattering, commercial, calm.
+- Hard key: graphic, dramatic, fashion, noir.
+- Backlight: separation, glow, silhouette, premium edge.
+- Rim light: subject outline, product glass, metal highlights.
+- Practical light: lamps, signs, screens, candles in the scene.
+- Motivated light: light that has a visible or logical source.
+- Low key: dark frame, selective highlights, suspense.
+- High key: bright, low contrast, beauty, comedy, clean product work.
+- Top light: interrogation, overhead realism, harsh institutional mood.
+- Window light: natural, intimate, documentary.
+
+## Lens feel
+
+- 14-20mm wide: scale, distortion, kinetic interiors, action.
+- 24-28mm wide-normal: environmental realism, travel, documentary.
+- 35mm: natural cinematic perspective, street, lifestyle, narrative.
+- 50mm: classic portrait and product balance.
+- 85mm: compressed portrait, beauty, isolation.
+- 100mm macro: product detail, jewelry, food texture, eyes.
+- Telephoto compression: distance, surveillance, fashion runway.
+
+## Depth of field
+
+- Shallow focus: isolate subject, premium portrait, product hero.
+- Deep focus: environment and blocking stay readable.
+- Rack focus: attention shifts between two subjects or details.
+
+## Color and grade
+
+- Clean neutral grade: commercial, e-commerce, architecture.
+- Warm golden grade: nostalgia, comfort, luxury hospitality.
+- Cool cyan shadows: thriller, tech, night exterior.
+- Desaturated earth palette: realism, documentary, survival.
+- High contrast monochrome: noir, fashion, graphic product.
+- Pastel palette: beauty, wellness, light lifestyle.
+- Sodium vapor night: urban realism, tension.
+
+## Texture
+
+- Fine film grain: organic image, period mood.
+- Clean digital: tech, luxury, e-commerce, architecture.
+- Halation: glowing highlights, dream, night practicals.
+- Mist filter: soft bloom, romance, beauty.
+- Crisp high shutter: action clarity.
+- Motion blur: speed, energy, handheld realism.

--- a/skills/cinematography/references/shot-language.md
+++ b/skills/cinematography/references/shot-language.md
@@ -1,0 +1,52 @@
+# Shot language reference
+
+## Shot sizes
+
+- Extreme close-up: one detail, texture, eye, hand, product edge.
+- Close-up: face or object detail with emotional focus.
+- Medium close-up: chest-up subject, useful for dialogue and portraits.
+- Medium shot: waist-up subject, body language visible.
+- Full shot: entire body or object, silhouette and stance readable.
+- Wide shot: subject inside environment.
+- Extreme wide: scale, isolation, worldbuilding, architecture.
+
+## Angles
+
+- Eye level: natural, direct, grounded.
+- Low angle: power, threat, awe.
+- High angle: vulnerability, surveillance, layout clarity.
+- Dutch angle: unease, instability. Use sparingly.
+- Over-the-shoulder: relationship, conversation, pursuit.
+- POV: subjective experience.
+- Profile: graphic composition, ritual, tension, fashion.
+
+## Camera movement
+
+- Slow push-in: attention, realization, premium product reveal.
+- Pull-back: isolation, context, reveal.
+- Dolly left or right: spatial discovery.
+- Tracking shot: follow action with continuity.
+- Crane up: scale reveal or emotional release.
+- Handheld: urgency, intimacy, instability.
+- Locked-off: control, deadpan, formalism, surveillance.
+- Orbit: product reveal, character inspection, heightened drama.
+- Macro glide: product texture, food, jewelry, electronics.
+
+## Composition
+
+- Centered symmetry: control, ritual, luxury, unease.
+- Rule of thirds: natural editorial composition.
+- Negative space: loneliness, premium ad copy area, tension.
+- Foreground obstruction: secrecy, surveillance, voyeurism.
+- Leading lines: architecture, movement, precision.
+- Frame within frame: confinement, observation, layered space.
+
+## Continuity language
+
+- "same subject and wardrobe as the reference"
+- "preserve product shape and label"
+- "continue from the uploaded first frame"
+- "single continuous shot"
+- "no cutaways"
+- "no time jump"
+- "same lighting direction throughout"

--- a/skills/commercial/SKILL.md
+++ b/skills/commercial/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: commercial
+description: >
+  Plan and run commercial image or video production with genmedia. Use this
+  for product photography, ads, e-commerce batches, product reveals, lifestyle
+  commercials, background replacement, social formats, and brand-safe prompt
+  work.
+---
+
+# Commercial production with genmedia
+
+Use this skill when the user wants advertising, product, brand, or e-commerce
+media. Load the reference files when you need prompt patterns or category
+examples:
+
+- `references/prompt-patterns.md`
+- `references/workflows.md`
+- `references/examples.md`
+
+Load `model-routing` alongside this skill for default endpoint choices.
+
+Keep the output production-focused. Do not add inflated marketing language,
+unsupported claims, fake text in the image, or em dashes.
+
+## Inputs to collect
+
+Only ask when the answer cannot be inferred from the task or the source files.
+
+- Product: exact product name, category, material, color, scale, logo rules.
+- Goal: hero shot, PDP image, ad creative, motion reveal, demo, UGC, lifestyle.
+- Platform: square, vertical, landscape, banner, transparent background, print.
+- Brand: premium, playful, clinical, athletic, minimal, natural, technical.
+- Source media: product packshot, logo, reference scene, prior generated asset.
+- Constraints: preserve packaging, avoid new labels, no fake readable copy.
+- Model preference: use `model-routing` defaults unless the user names a model
+  or the job is unusually expensive.
+
+## Genmedia workflow
+
+1. Start from routed endpoint IDs.
+
+   ```bash
+   genmedia models --endpoint_id openai/gpt-image-2 --json
+   genmedia models --endpoint_id fal-ai/nano-banana-pro/edit --json
+   genmedia models --endpoint_id fal-ai/nano-banana-2 --json
+   genmedia models --endpoint_id bytedance/seedance-2.0/image-to-video --json
+   ```
+
+   Use text search only as fallback discovery for a missing utility or
+   unsupported role:
+
+   ```bash
+   genmedia models "background removal product image" --json
+   genmedia docs "commercial product image generation" --json
+   ```
+
+2. Inspect the selected endpoint before running.
+
+   ```bash
+   genmedia schema <endpoint_id> --json
+   genmedia pricing <endpoint_id> --json
+   ```
+
+3. Upload every local or remote reference file.
+
+   ```bash
+   genmedia upload ./product.png --json
+   genmedia upload ./logo.png --json
+   ```
+
+4. Run still-image jobs synchronously when they are quick.
+
+   ```bash
+   genmedia run <endpoint_id> \
+     --prompt "<commercial prompt>" \
+     --image_url "<uploaded product url if supported>" \
+     --download "./outputs/commercial/{request_id}_{index}.{ext}" \
+     --json
+   ```
+
+5. Run video jobs async and download from `status`.
+
+   ```bash
+   genmedia run <endpoint_id> \
+     --prompt "<motion prompt>" \
+     --image_url "<uploaded hero frame if supported>" \
+     --async \
+     --json
+
+   genmedia status <endpoint_id> <request_id> \
+     --download "./outputs/commercial/{request_id}_{index}.{ext}" \
+     --json
+   ```
+
+6. Use schema fields exactly. Do not pass guessed flags. If the model uses
+   `image_urls`, `reference_image_url`, `aspect_ratio`, `duration`, `seed`, or
+   another name, mirror that schema.
+
+## Prompt build order
+
+Write prompts in this order so commercial intent stays clear:
+
+1. Product invariant: exact object, material, color, packaging, scale.
+2. Commercial role: hero image, PDP image, launch teaser, demo shot, social ad.
+3. Setting: surface, background, props, environment, distance from product.
+4. Lighting: softbox, strip light, rim light, backlight, caustics, practicals.
+5. Camera: angle, focal length feel, macro, depth of field, motion if video.
+6. Composition: centered, negative space, safe zone, text-free area, platform.
+7. Brand tone: premium, clean, clinical, bold, energetic, warm, editorial.
+8. Guardrails: preserve logo and packaging, no extra text, no distorted labels.
+
+Do not promise claims like "best", "clinically proven", "50 percent faster",
+or celebrity endorsements unless the user provides that copy.
+
+## Model routing
+
+- Text-heavy ads, labels, posters, UI mockups, packaging copy, and
+  infographics: use `openai/gpt-image-2` at `quality=high`. Prefer 2K or 4K
+  when the final must carry small readable details. Treat this as expensive.
+- Premium realistic stills: use `openai/gpt-image-2`.
+- Premium stylized stills: use `openai/gpt-image-2`, then
+  `fal-ai/nano-banana-pro`, then `fal-ai/nano-banana-2`.
+- Fast draft stills: use `fal-ai/flux-2/klein/9b`.
+- Image edits: use `fal-ai/nano-banana-pro/edit`, then
+  `openai/gpt-image-2/edit`, then `fal-ai/bytedance/seedream/v5/lite/edit`.
+- Product fidelity: use `fal-ai/nano-banana-pro`, `fal-ai/nano-banana-2`, or
+  `fal-ai/bytedance/seedream/v5/lite/text-to-image`; use the matching edit
+  endpoint when a product reference image exists.
+- Product reveal video: create or upload a strong hero frame, then use
+  `bytedance/seedance-2.0/image-to-video` for final quality.
+- Fast or lower-cost video draft: use `xai/grok-imagine-video/image-to-video`
+  or `xai/grok-imagine-video/text-to-video`.
+- E-commerce batch: keep the same prompt skeleton and vary only background,
+  crop, lighting, or platform format.
+- Text overlays: generate with empty safe space. Add final text in a design or
+  editing tool unless the selected model is explicitly good at typography.
+- Background removal or cleanup: search for background removal, segmentation,
+  inpainting, or product editing models and inspect their schemas.
+- Final delivery: use `--download` with `{request_id}` and `{index}`.
+
+## Quality bar
+
+Before returning, check:
+
+- Product shape, logo, material, and color are not invented or distorted.
+- The composition leaves enough room for platform crop and optional copy.
+- Background props support the product and do not compete with it.
+- Any generated text is absent or intentionally controlled.
+- Lighting makes sense for the product material.
+- Output paths are from `downloaded_files[]`, not manually curled URLs.
+
+If the result misses product fidelity, switch from text-only generation to a
+reference or edit workflow before retrying.

--- a/skills/commercial/references/examples.md
+++ b/skills/commercial/references/examples.md
@@ -1,0 +1,50 @@
+# Commercial examples
+
+These are reference-quality prompts. Adapt them to the user's actual product,
+files, and selected model schema.
+
+## Skincare serum hero
+
+```text
+amber glass skincare serum bottle with matte black dropper, exact label and
+packaging preserved from the reference image, standing on pale stone, soft
+diffused key light from upper left, thin rim light on glass edges, subtle
+water condensation, warm beige background, centered square crop, premium beauty
+product photography, no added text, no extra bottles, no warped label
+```
+
+## Sneaker launch still
+
+```text
+single white running sneaker with blue outsole accents, three-quarter side
+view, suspended just above a clean concrete surface, sharp shadow under sole,
+crisp studio flash, slight motion dust behind heel, athletic launch campaign
+style, product fully visible, no brand changes, no text
+```
+
+## Beverage pour video
+
+```text
+8 second commercial video of a cold craft soda can on wet black stone,
+opening on a close-up of condensation, slow push-in as liquid pours into a
+glass beside it, controlled splash, amber backlight through the liquid, premium
+beverage ad pacing, can shape and label remain stable, no added text
+```
+
+## SaaS device mockup
+
+```text
+thin laptop on a clean walnut desk showing an abstract dashboard interface,
+morning side light, shallow depth of field, organized workspace with notebook
+and pen, calm productivity mood, wide landscape crop with negative space on
+right for headline, no readable fake UI text
+```
+
+## Background replacement
+
+```text
+preserve the uploaded ceramic coffee mug exactly, replace background with a
+bright Scandinavian kitchen counter, soft morning window light from left,
+realistic contact shadow and reflection, warm lifestyle product photography,
+no new logo, no deformation, no text
+```

--- a/skills/commercial/references/prompt-patterns.md
+++ b/skills/commercial/references/prompt-patterns.md
@@ -1,0 +1,74 @@
+# Commercial prompt patterns
+
+Use these as structure, not filler. Replace bracketed details with the user's
+product and platform constraints.
+
+## Product hero image
+
+```text
+[exact product] as the only hero object, [material and color], placed on
+[surface], [background], [lighting setup], [camera angle and lens feel],
+[composition and crop], premium commercial product photography, clean edges,
+accurate packaging, no extra text, no fake labels, no hands unless requested
+```
+
+## Product with lifestyle context
+
+```text
+[exact product] used in [specific real setting], natural interaction with
+[person or environment], product remains sharp and readable, [time of day],
+[brand tone], [lens feel], [platform crop], no invented claims, no extra logos
+```
+
+## E-commerce PDP image
+
+```text
+[exact product] centered on seamless [background color], front-facing,
+accurate silhouette, even softbox lighting, realistic shadow, high detail,
+no props, no decorative text, clean product catalog photography
+```
+
+## Social ad safe-zone composition
+
+```text
+[product] in [scene], subject placed in [left/right/lower third], large clean
+negative space on [side] for copy, [platform aspect ratio], strong first-frame
+readability, no text generated inside the image
+```
+
+## Product reveal video
+
+```text
+[duration] second product reveal of [product], starts with [opening frame],
+camera [movement], product rotates or reveals [feature], [lighting change],
+[background motion], premium commercial pacing, product remains centered and
+undistorted, no text, no logo morphing
+```
+
+## Background replacement
+
+```text
+keep the uploaded product exactly unchanged, replace only the background with
+[environment], match reflections and contact shadows, [lighting direction],
+commercial product photography, no product deformation, no added labels
+```
+
+## Product material cues
+
+- Glass: backlight, rim light, caustics, transparent edges, controlled
+  reflections.
+- Metal: strip highlights, hard rim, dark flags, precise specular lines.
+- Plastic: softbox, clean shadow, realistic molded edges, no over-gloss.
+- Fabric: side light, visible weave, natural folds, accurate color.
+- Food: soft directional light, steam or condensation only when plausible.
+- Jewelry: macro lens feel, dark cards, crisp sparkle, controlled highlights.
+
+## Negative prompt components
+
+Use only when the selected model supports a negative prompt:
+
+```text
+extra text, fake logo, misspelled label, deformed packaging, duplicated
+product, cropped product, warped geometry, bad reflections, messy background,
+unreadable brand mark, synthetic hands, low resolution
+```

--- a/skills/commercial/references/workflows.md
+++ b/skills/commercial/references/workflows.md
@@ -1,0 +1,51 @@
+# Commercial workflows
+
+## Hero image from product reference
+
+1. Upload the product image with `genmedia upload`.
+2. Search for image editing, reference image, or product photography models.
+3. Inspect schema and choose the fields that preserve product identity.
+4. Prompt for surface, lighting, crop, and background. Keep the product
+   invariant short and exact.
+5. Run with `--download "./outputs/commercial/{request_id}_{index}.{ext}"`.
+6. Reject outputs with altered logos, warped packaging, or invented text.
+
+## Text-to-image product concept
+
+Use when no reference exists or the user wants early creative exploration.
+
+1. Ask or infer product category, materials, and brand tone.
+2. Generate 2 to 4 controlled variants if the model supports count.
+3. Keep each variant different by one dimension only: background, lighting,
+   camera angle, or prop set.
+4. Pick the strongest frame before moving to video or batch production.
+
+## Product reveal video
+
+1. Create a still hero frame or upload the user's approved product frame.
+2. Search image-to-video models and inspect `duration`, `aspect_ratio`, image
+   input, seed, and motion controls.
+3. Keep motion simple: push-in, turntable, parallax, reveal, pour, unwrap.
+4. Run async, then download from `genmedia status`.
+5. If the product changes shape, reduce motion and strengthen identity
+   constraints.
+
+## E-commerce batch
+
+1. Build a base prompt with exact product invariants.
+2. Create a small matrix: white background, brand-color background, lifestyle,
+   scale/detail, packaging close-up.
+3. Use consistent output naming with `{request_id}_{index}`.
+4. Return a table of output path, concept, endpoint, and notable defects.
+
+## Ad creative set
+
+Produce separate assets for:
+
+- Hook frame: product and benefit visible in under one second.
+- Proof frame: product detail, ingredient, feature, texture, or before-after.
+- Lifestyle frame: human or environmental context.
+- Conversion frame: clean safe-zone layout for external text and CTA.
+
+Do not generate legal claims, pricing, discounts, or health claims unless the
+user supplies the exact copy.

--- a/skills/index.json
+++ b/skills/index.json
@@ -2,6 +2,84 @@
   "version": 1,
   "skills": [
     {
+      "name": "character-design",
+      "description": "Build consistent character designs and character media with genmedia. Use this for original characters, reference sheets, expression sheets, outfit variations, identity-preserving edits, and character-to-video workflows.",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "sha256": "1f62641d84b3dc0f2c0e13663afbb71cd9682483e82b920cc53450713c5f5d57",
+          "bytes": 5147
+        },
+        {
+          "path": "references/anchor-system.md",
+          "sha256": "397f23ee81160990aad789931649aded955314c583539665fb89f1bf15831acd",
+          "bytes": 1898
+        },
+        {
+          "path": "references/examples.md",
+          "sha256": "1980d83b82d2ee18417aa3d704a30c4ad17b17e93a3676ed0be1508e64dd849f",
+          "bytes": 2028
+        },
+        {
+          "path": "references/prompt-patterns.md",
+          "sha256": "256ba5364c0b9b52538774e1c307ec1e8dbeffcd5cd85950e2b3551bcac382bc",
+          "bytes": 1880
+        }
+      ]
+    },
+    {
+      "name": "cinematography",
+      "description": "Design cinematic image and video prompts for genmedia. Use this for shot language, camera movement, lighting, lens choices, color grade, film texture, scene blocking, and production-ready visual direction.",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "sha256": "8d23b4836a7621e1c9715def480d95e3b4b2135bfd7995e2800013949fc8eba7",
+          "bytes": 4925
+        },
+        {
+          "path": "references/examples.md",
+          "sha256": "e143734e15f79411240056f22b9def4d8053b11cb54958213e68eec9899778c8",
+          "bytes": 1674
+        },
+        {
+          "path": "references/lighting-lens-color.md",
+          "sha256": "e9bbe4c61c98c0cf98cb652101b0e16f670184d7236e5509e9abc2e8de195f2a",
+          "bytes": 1995
+        },
+        {
+          "path": "references/shot-language.md",
+          "sha256": "21ca47d38ae6388293c410c4181fd2d84f8058fbcd36bf3db5d1643179e3faaf",
+          "bytes": 1901
+        }
+      ]
+    },
+    {
+      "name": "commercial",
+      "description": "Plan and run commercial image or video production with genmedia. Use this for product photography, ads, e-commerce batches, product reveals, lifestyle commercials, background replacement, social formats, and brand-safe prompt work.",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "sha256": "be01bc3eabf0cd1004b9ce6a1bf9725aa0bb308a3c499483971ce423e392e3b6",
+          "bytes": 6104
+        },
+        {
+          "path": "references/examples.md",
+          "sha256": "529a12813026c6f77c5171b99cfb966b57c81b36594626e8dd7a5eed81c7ba15",
+          "bytes": 1818
+        },
+        {
+          "path": "references/prompt-patterns.md",
+          "sha256": "491aaf66cac663b453d395b0a3c690f3da1a11a93292361b6589a6d6fec26be4",
+          "bytes": 2620
+        },
+        {
+          "path": "references/workflows.md",
+          "sha256": "e1cd239afb8a1b8f3bf5e7ae46d063b15a2cc73e0b9a28373b1d0acb344f135f",
+          "bytes": 2111
+        }
+      ]
+    },
+    {
       "name": "genmedia",
       "description": "Run a fal.ai model end-to-end with the genmedia CLI. Use this when the user asks to generate an image, video, or audio; convert media; upscale or restyle; run any fal.ai model; or \"use genmedia\" for a task. Guides discovery, schema inspection, input preparation, execution, and result handling.",
       "files": [
@@ -20,6 +98,74 @@
           "path": "SKILL.md",
           "sha256": "dbc36f1091a266fa2cb4526c088d1a457523e7ed6ff0eef415c17371dd9d78b3",
           "bytes": 8957
+        }
+      ]
+    },
+    {
+      "name": "model-routing",
+      "description": "Choose default fal.ai endpoint IDs for genmedia production skills. Use this with commercial, character-design, cinematography, storytelling, and workflow when the user has not named a specific model.",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "sha256": "aaa36cb33dde91821127d44c238fa92256df4048b420834b064c64a277612fbd",
+          "bytes": 4704
+        }
+      ]
+    },
+    {
+      "name": "storytelling",
+      "description": "Build multi-shot narrative image, video, and audio workflows with genmedia. Use this for storyboards, shot lists, multi-prompt video, first-frame to last-frame pipelines, social stories, brand films, and sequence continuity.",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "sha256": "84db6699346718074e2c3c9e6ac1f9cd650e97f588023d9050ba8cf04d11b0f6",
+          "bytes": 5658
+        },
+        {
+          "path": "references/examples.md",
+          "sha256": "1b882303a6e7546896c4045a0b57f70cb2cd60afb8217ff8266865215ef0e507",
+          "bytes": 2802
+        },
+        {
+          "path": "references/shot-planning.md",
+          "sha256": "8ceccbda8fdeab87f1c4c5f1303562d3d37eca8f461e219e3650e22eb280ba4c",
+          "bytes": 1883
+        },
+        {
+          "path": "references/workflows.md",
+          "sha256": "618762ee0c9304f1a1065dc8f10de6bcd41242a59334b2a6f8e77badfa51afee",
+          "bytes": 2094
+        }
+      ]
+    },
+    {
+      "name": "workflow",
+      "description": "Design and execute multi-step media workflows with genmedia. Use this for pipelines that combine planning, generation, editing, image or video utilities, audio, subtitles, batching, and final delivery manifests.",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "sha256": "a4187490f953eb54f130a29f1a4f08b48a65f013337f2be85451705eb3ba2cba",
+          "bytes": 5183
+        },
+        {
+          "path": "references/node-rules.md",
+          "sha256": "cf449fe1aa4bf0338ae1cc0a226fcb675eebf9597017e04eb4f52083a3b57fef",
+          "bytes": 2826
+        },
+        {
+          "path": "references/pipeline-patterns.md",
+          "sha256": "dcfe4b87b0a3b02883ff98c3437f91145d933e5b669caccab736c1f9e6c40988",
+          "bytes": 3623
+        },
+        {
+          "path": "references/recipes.md",
+          "sha256": "c5b332b61fc557595ce2e9e992ec9e9944936008db9ac064b9872d12696a4a7e",
+          "bytes": 3036
+        },
+        {
+          "path": "references/utility-endpoints.md",
+          "sha256": "c1921d500107659236c401451ecc1e9655576b5b35fb5e7bb1f8a308f0287501",
+          "bytes": 3401
         }
       ]
     }

--- a/skills/model-routing/SKILL.md
+++ b/skills/model-routing/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: model-routing
+description: >
+  Choose default fal.ai endpoint IDs for genmedia production skills. Use this
+  with commercial, character-design, cinematography, storytelling, and workflow
+  when the user has not named a specific model.
+---
+
+# Genmedia model routing
+
+Use these endpoint defaults when a domain skill needs a model. These choices
+come from project-specific guidance. Still run `genmedia schema <endpoint_id>
+--json` before execution and `genmedia pricing <endpoint_id> --json` when cost
+matters.
+
+Endpoint-first rule:
+
+1. Pick the endpoint ID from this skill.
+2. Verify it with `genmedia models --endpoint_id <endpoint_id> --json`.
+3. Inspect it with `genmedia schema <endpoint_id> --json`.
+4. Check `genmedia pricing <endpoint_id> --json` when cost matters.
+5. Use text search only if the routed endpoint is missing, deprecated,
+   rejected, or the task needs a model role not covered here.
+
+Do not invent endpoint IDs.
+
+## Image generation
+
+### Text-heavy image work
+
+Use for infographics, UI mockups, posters, product labels, packaging text,
+readable signs, book covers, educational diagrams, and any output where text
+inside the image must be accurate.
+
+1. `openai/gpt-image-2`
+   - Use `quality=high`.
+   - Prefer 2K or 4K custom `image_size` when the final must be detailed.
+   - Treat as expensive. Do not use it for cheap drafts.
+2. `fal-ai/nano-banana-pro`
+   - Use as the second choice when text is important but GPT Image 2 is not
+     available or the user accepts a lower ceiling.
+
+Cheap and simple models are not acceptable for text-heavy production.
+
+### Premium still images
+
+Use for commercial stills, realistic product scenes, editorial photography,
+cinematic keyframes, and high-quality visual concepts.
+
+- More realistic output: `openai/gpt-image-2`.
+- High-quality styled output: `openai/gpt-image-2`.
+- One step down: `fal-ai/nano-banana-pro`.
+- Strong cheaper alternative: `fal-ai/nano-banana-2`.
+
+### Fast draft images
+
+Use for quick concepts, mood options, rough composition, and cheap iteration.
+
+- `fal-ai/flux-2/klein/9b`
+
+Do not use fast draft output as final commercial delivery unless the user asks.
+
+## Image editing
+
+Use for background replacement, relighting, cleanup, object changes, product
+placement, outfit changes, character edits, and multi-image composition.
+
+1. `fal-ai/nano-banana-pro/edit`
+2. `openai/gpt-image-2/edit`
+3. `fal-ai/bytedance/seedream/v5/lite/edit`
+
+For product fidelity, also consider:
+
+- `fal-ai/nano-banana-pro`
+- `fal-ai/nano-banana-2`
+- `fal-ai/bytedance/seedream/v5/lite/text-to-image`
+- `fal-ai/nano-banana-2/edit`
+
+For consistent characters, use `openai/gpt-image-2` first. If editing an
+existing character image, inspect `openai/gpt-image-2/edit`.
+
+## Video generation
+
+### Highest quality video
+
+Use Seedance 2.0 first for final, high-quality video.
+
+- Text to video: `bytedance/seedance-2.0/text-to-video`
+- Image to video: `bytedance/seedance-2.0/image-to-video`
+- Reference to video: `bytedance/seedance-2.0/reference-to-video`
+
+Fast variants exist for lower latency:
+
+- `bytedance/seedance-2.0/fast/text-to-video`
+- `bytedance/seedance-2.0/fast/image-to-video`
+- `bytedance/seedance-2.0/fast/reference-to-video`
+
+### Fast or lower-cost video
+
+Use Grok Imagine Video for fast, lower-cost motion previews and economical
+video generation.
+
+- Text to video: `xai/grok-imagine-video/text-to-video`
+- Image to video: `xai/grok-imagine-video/image-to-video`
+- Video edit: `xai/grok-imagine-video/edit-video`
+
+### Multi-shot storytelling
+
+Use in this order:
+
+1. `bytedance/seedance-2.0/text-to-video`
+2. `bytedance/seedance-2.0/image-to-video`
+3. `bytedance/seedance-2.0/reference-to-video`
+4. `fal-ai/kling-video/v3/pro/text-to-video`
+5. `fal-ai/kling-video/v3/pro/image-to-video`
+6. `alibaba/happy-horse/text-to-video`
+7. `alibaba/happy-horse/image-to-video`
+
+Use Kling v3 when its multi-prompt, element, or custom element controls match
+the requested shot plan. Use Happy Horse after Seedance and Kling unless the
+user specifically asks for it.
+
+### Native audio and lip-sync
+
+Use for talking avatars, speech-driven face motion, product spokespersons,
+UGC-style presenters, and lip-sync from an image plus audio or text.
+
+1. `veed/fabric-1.0`
+   - Image plus uploaded audio.
+2. `veed/fabric-1.0/text`
+   - Image plus text speech.
+3. `fal-ai/creatify/aurora`
+   - Avatar video from image plus audio, with optional visual direction.
+
+## Utility endpoints
+
+Workflow utility endpoint IDs live in the `workflow` skill reference:
+`workflow/references/utility-endpoints.md`.
+
+Utility endpoints are allowed to be explicit because they are deterministic
+tools, not creative model choices. Always inspect schema before use.

--- a/skills/storytelling/SKILL.md
+++ b/skills/storytelling/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: storytelling
+description: >
+  Build multi-shot narrative image, video, and audio workflows with genmedia.
+  Use this for storyboards, shot lists, multi-prompt video, first-frame to
+  last-frame pipelines, social stories, brand films, and sequence continuity.
+---
+
+# Storytelling with genmedia
+
+Use this skill when the user wants a sequence, not a single asset. Load
+references as needed:
+
+- `references/shot-planning.md`
+- `references/workflows.md`
+- `references/examples.md`
+
+Load `model-routing` alongside this skill for default endpoint choices.
+
+The goal is to produce clear story beats and executable genmedia runs. Avoid
+generic inspiration copy, fake dialogue, and em dashes.
+
+## Inputs to collect
+
+Ask only when missing information affects execution.
+
+- Format: ad, short film, music video, documentary, tutorial, social story.
+- Duration and aspect ratio.
+- Number of shots or allowed range.
+- Main subject, character, product, or location.
+- Continuity anchors: character, product, wardrobe, environment, color.
+- Source media: first frame, reference image, product shot, audio track.
+- Audio needs: narration, music, sound design, transcript, no audio.
+- Preferred model or model family, if the user wants to decide quality, cost,
+  speed, audio, or multi-shot tradeoffs.
+
+## Genmedia workflow
+
+1. Start from routed endpoint IDs.
+
+   ```bash
+   genmedia models --endpoint_id bytedance/seedance-2.0/text-to-video --json
+   genmedia models --endpoint_id bytedance/seedance-2.0/image-to-video --json
+   genmedia models --endpoint_id bytedance/seedance-2.0/reference-to-video --json
+   genmedia models --endpoint_id fal-ai/kling-video/v3/pro/text-to-video --json
+   genmedia models --endpoint_id alibaba/happy-horse/text-to-video --json
+   genmedia models --endpoint_id veed/fabric-1.0 --json
+   ```
+
+   Use text search only as fallback discovery for an unsupported sequence
+   control:
+
+   ```bash
+   genmedia models "first frame last frame video generation" --json
+   genmedia docs "multi shot video generation" --json
+   ```
+
+2. Inspect schema before planning exact payloads.
+
+   ```bash
+   genmedia schema <endpoint_id> --json
+   genmedia pricing <endpoint_id> --json
+   ```
+
+3. Upload references.
+
+   ```bash
+   genmedia upload ./first-frame.png --json
+   genmedia upload ./character.png --json
+   genmedia upload ./product.png --json
+   genmedia upload ./voiceover.wav --json
+   ```
+
+4. Choose the sequence route.
+
+   - Highest quality video: start with Seedance 2.0 endpoints from
+     `model-routing`.
+   - Native multi-prompt: use if schema has shot arrays, prompt lists, or
+     timeline fields.
+   - First/last frame: use for controlled transitions between key frames.
+   - Image-to-video per shot: use for maximum continuity from approved stills.
+   - Manual per-shot generation: use when the model only supports one prompt.
+   - Audio-first: generate or upload audio, then plan visual shot lengths.
+   - Lip-sync or talking avatar: use Fabric 1.0 or Creatify Aurora from
+     `model-routing`.
+
+5. Run long jobs async and download every result with a unique template.
+
+   ```bash
+   genmedia run <endpoint_id> \
+     --prompt "<shot or sequence prompt>" \
+     --async \
+     --json
+
+   genmedia status <endpoint_id> <request_id> \
+     --download "./outputs/story/{request_id}_{index}.{ext}" \
+     --json
+   ```
+
+6. Return a shot table with endpoint, request id, prompt summary, local path,
+   and any continuity issues. Genmedia downloads clips; it does not replace a
+   timeline editor unless the chosen model returns a complete stitched video.
+
+## Shot planning
+
+Plan every sequence as beats first:
+
+1. Hook: immediate visual reason to keep watching.
+2. Setup: who, what, where, and why it matters.
+3. Development: movement, discovery, proof, or escalation.
+4. Turn: reveal, transformation, result, or emotional change.
+5. Close: final image, product memory, CTA-safe frame, or unresolved mood.
+
+For each shot, write:
+
+- Shot number and duration.
+- Story purpose.
+- Visual prompt.
+- Continuity anchor.
+- Input reference, if any.
+- Genmedia endpoint.
+- Expected output path.
+
+## Prompt build order
+
+Use this structure for each shot:
+
+```text
+SHOT [number], [duration]:
+[story purpose]. [subject and action]. [location and time]. [camera framing].
+[camera movement]. [lighting and color]. [continuity anchor]. [transition or
+relationship to previous shot].
+```
+
+Keep one shot to one clear action unless the selected model supports multi-shot
+or timeline prompting.
+
+## Model routing
+
+- Highest quality video: `bytedance/seedance-2.0/text-to-video`,
+  `bytedance/seedance-2.0/image-to-video`, or
+  `bytedance/seedance-2.0/reference-to-video`.
+- Fast or lower-cost video: `xai/grok-imagine-video/text-to-video` or
+  `xai/grok-imagine-video/image-to-video`.
+- Multi-shot sequence: Seedance 2.0 first, then
+  `fal-ai/kling-video/v3/pro/text-to-video`, then
+  `fal-ai/kling-video/v3/pro/image-to-video`, then
+  `alibaba/happy-horse/text-to-video` or
+  `alibaba/happy-horse/image-to-video`.
+- Text-heavy keyframes, boards, UI frames, posters, or infographics:
+  `openai/gpt-image-2` at `quality=high`.
+- Talking avatar, native audio, or lip-sync:
+  `veed/fabric-1.0`, `veed/fabric-1.0/text`, or `fal-ai/creatify/aurora`.
+
+## Quality bar
+
+Before returning:
+
+- Shot order has a clear narrative function.
+- The first shot is strong enough for the platform.
+- Continuity anchors are repeated without bloating every prompt.
+- Camera motion is varied but not random.
+- Durations add up to the requested runtime.
+- Async request IDs and downloaded files are recorded.
+- The model's actual schema, not assumptions, drove the final command.

--- a/skills/storytelling/references/examples.md
+++ b/skills/storytelling/references/examples.md
@@ -1,0 +1,65 @@
+# Storytelling examples
+
+These examples show planning density and prompt tone. Adapt to the user's model
+schema and references.
+
+## 15 second coffee social ad
+
+| Shot | Duration | Prompt |
+| --- | --- | --- |
+| 1 | 2s | macro close-up of espresso crema swirling in a glass cup, warm morning window light, shallow focus, immediate sensory hook |
+| 2 | 4s | same coffee cup placed beside a small bag of beans on a clean kitchen counter, slow push-in, product and texture readable |
+| 3 | 5s | hand pours milk into the coffee, soft cloud bloom, controlled motion, warm lifestyle lighting, no text |
+| 4 | 4s | final hero frame of cup and beans with clean negative space on right for copy, calm premium breakfast mood |
+
+Execution note: generate still or video per shot unless the selected endpoint
+supports a prompt list.
+
+## 30 second architecture brand film
+
+| Shot | Duration | Purpose |
+| --- | --- | --- |
+| 1 | 4s | dawn exterior of a modern house, wide static frame, warm interior lights |
+| 2 | 5s | slow tracking shot along concrete wall and timber detail, tactile proof |
+| 3 | 5s | architect's hand sketches over plan, natural desk light, human process |
+| 4 | 6s | family crosses the living room, soft backlight, space feels livable |
+| 5 | 6s | crane up from courtyard to roofline, shows scale and geometry |
+| 6 | 4s | quiet final exterior with empty safe space for brand mark |
+
+Continuity anchor:
+
+```text
+same house, same material palette of warm timber, pale concrete, black steel
+frames, and soft morning light
+```
+
+## Cinematic reunion scene
+
+| Shot | Duration | Prompt |
+| --- | --- | --- |
+| 1 | 5s | empty train platform in blue hour rain, wide locked-off frame, practical lights reflected on wet ground |
+| 2 | 4s | close-up of woman noticing someone off screen, same coat and hairstyle, soft backlight, restrained emotion |
+| 3 | 4s | medium shot of man stepping from train doorway, matching eyeline, cool station light |
+| 4 | 5s | slow tracking two-shot as they walk toward each other, shallow depth of field, no crowd distraction |
+| 5 | 6s | close hands meeting, rain on sleeves, quiet emotional detail |
+| 6 | 6s | wide final frame of both under station clock, warm practical light, unresolved calm |
+
+## Product launch sequence
+
+```text
+SHOT 1, 3s:
+black screen opens to a thin rim light tracing the product silhouette, centered
+macro frame, premium suspense, no text.
+
+SHOT 2, 4s:
+slow orbit reveals the product material and main contour, controlled studio
+reflections, same product shape and logo placement as the reference.
+
+SHOT 3, 5s:
+close-up of the key feature in use, clean hand interaction, product remains
+sharp, no fake labels.
+
+SHOT 4, 3s:
+final hero composition on simple surface with large negative space for copy,
+brand-safe end frame, no generated text.
+```

--- a/skills/storytelling/references/shot-planning.md
+++ b/skills/storytelling/references/shot-planning.md
@@ -1,0 +1,69 @@
+# Shot planning reference
+
+## Basic sequence shapes
+
+## 15 second social ad
+
+| Shot | Time | Purpose | Visual role |
+| --- | --- | --- | --- |
+| 1 | 0-2s | Hook | striking product or problem image |
+| 2 | 2-6s | Context | product in use or character reaction |
+| 3 | 6-11s | Proof | feature, texture, process, result |
+| 4 | 11-15s | Close | memorable final frame with safe space |
+
+## 30 second commercial
+
+| Shot | Time | Purpose | Visual role |
+| --- | --- | --- | --- |
+| 1 | 0-3s | Hook | image that defines the world |
+| 2 | 3-7s | Product or hero | show subject clearly |
+| 3 | 7-13s | Benefit | action, feature, transformation |
+| 4 | 13-20s | Lifestyle or proof | real context, emotion, result |
+| 5 | 20-27s | Escalation | strongest beauty or motion shot |
+| 6 | 27-30s | End frame | clean brand-safe final composition |
+
+## Short cinematic scene
+
+| Shot | Purpose |
+| --- | --- |
+| Establishing | where the scene happens and mood |
+| Character reveal | who matters |
+| Action beat | what changes |
+| Reaction | emotional consequence |
+| Detail insert | object, clue, texture, proof |
+| Resolution | new state or unanswered tension |
+
+## Continuity anchors
+
+Character anchor:
+
+```text
+same character face, hair, wardrobe, age, posture, and style as the approved
+reference
+```
+
+Product anchor:
+
+```text
+same product shape, color, packaging, logo placement, and material as the
+reference
+```
+
+Location anchor:
+
+```text
+same room layout, window direction, color palette, and time of day
+```
+
+Motion anchor:
+
+```text
+single continuous shot, starts where previous shot ended, no time jump
+```
+
+## Pacing guidance
+
+- Fast: 1-3 second shots, strong motion, clear graphic frames.
+- Medium: 3-6 second shots, product demos, lifestyle, dialogue-like scenes.
+- Slow: 6-10 second shots, luxury, drama, architecture, atmosphere.
+- Variable: fast hook, slower proof, strong final frame.

--- a/skills/storytelling/references/workflows.md
+++ b/skills/storytelling/references/workflows.md
@@ -1,0 +1,56 @@
+# Storytelling workflows
+
+## Native multi-prompt sequence
+
+Use only when schema supports multiple prompts, shot arrays, scenes, timeline,
+or keyframe-like fields.
+
+1. Inspect schema and identify the exact multi-shot fields.
+2. Convert the story into concise shot prompts.
+3. Keep one continuity anchor outside the repeated shot details if schema
+   supports a global prompt.
+4. Run async and download the completed result.
+5. Check whether the model returned one video or per-shot files.
+
+## Manual per-shot video
+
+Use when the model supports only one shot at a time.
+
+1. Create a shot table.
+2. Generate or upload a reference frame for each shot.
+3. Run each shot with unique download templates.
+4. Record endpoint, request id, prompt, local output path, and defects.
+5. Return clips in timeline order. Do not claim they are stitched unless they
+   are actually stitched by the model or another tool.
+
+## First-frame to last-frame
+
+1. Generate or choose the opening frame.
+2. Generate or choose the target final frame.
+3. Upload both frames if local.
+4. Inspect schema for accepted first/last frame fields.
+5. Prompt the transition as one physical motion or transformation.
+6. Run async and download.
+
+## Character narrative
+
+1. Use `character-design` to create or confirm the anchor.
+2. Build shot variables around action, expression, and location.
+3. Use image-to-video from approved stills when identity drift matters.
+4. Compare each result to the anchor before advancing to the next shot.
+
+## Product narrative
+
+1. Use `commercial` to define product invariants.
+2. Plan the sequence around hook, feature, context, proof, final frame.
+3. Use the same product reference for every shot if schema allows it.
+4. Keep motion modest when packaging fidelity matters.
+
+## Audio narrative
+
+1. Search for narration, music, or sound generation models with `genmedia
+   models`.
+2. Inspect schema and run audio jobs with `--download`.
+3. Use transcript or beat timing to set shot durations.
+4. Return audio path and visual clip paths separately unless a model produces
+   combined audio-video output.

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: workflow
+description: >
+  Design and execute multi-step media workflows with genmedia. Use this for
+  pipelines that combine planning, generation, editing, image or video
+  utilities, audio, subtitles, batching, and final delivery manifests.
+---
+
+# Workflow production with genmedia
+
+Use this skill when a single model call is not enough. A workflow is a planned
+sequence of genmedia calls with clear inputs, outputs, dependencies, and
+quality checks.
+
+Load references as needed:
+
+- `references/pipeline-patterns.md`
+- `references/node-rules.md`
+- `references/utility-endpoints.md`
+- `references/recipes.md`
+- `model-routing` for creative model defaults
+
+Use `model-routing` for default creative model choices. Still inspect schemas,
+check pricing when cost matters, and use exact endpoint fields.
+
+## Inputs to collect
+
+Ask only for missing information that changes the pipeline:
+
+- Final deliverable: image set, video, clips, audio, subtitles, dataset, social
+  batch, product campaign, storyboard, style exploration.
+- Source assets: product images, character references, first frames, video,
+  audio, logo, transcript, brand guide.
+- Runtime limits: quality target, cost sensitivity, number of variants,
+  duration, aspect ratios, deadline.
+- Continuity requirements: product identity, character face, scene layout,
+  voice, color grade.
+- Model preference: ask the user only when quality, speed, cost, or audio
+  tradeoffs are not clear from the brief.
+
+## Core workflow
+
+1. Write a short pipeline graph before running anything.
+
+   ```text
+   input assets -> planner -> generation nodes -> utility nodes -> QA -> final outputs
+   ```
+
+2. Resolve endpoints for each role. Check known endpoint IDs first.
+
+   ```bash
+   genmedia models --endpoint_id openai/gpt-image-2 --json
+   genmedia models --endpoint_id fal-ai/nano-banana-pro/edit --json
+   genmedia models --endpoint_id bytedance/seedance-2.0/image-to-video --json
+   genmedia models --endpoint_id xai/grok-imagine-video/image-to-video --json
+   genmedia models --endpoint_id veed/fabric-1.0 --json
+   ```
+
+   Use text search only as fallback discovery for roles not covered by
+   `model-routing` or the utility reference:
+
+   ```bash
+   genmedia models "image generation product photography" --json
+   genmedia models "image editing reference preservation" --json
+   genmedia models "image to video" --json
+   genmedia models "subtitle video utility" --json
+   genmedia docs "fal.ai workflow utility endpoints" --json
+   ```
+
+3. Inspect every endpoint before use.
+
+   ```bash
+   genmedia schema <endpoint_id> --json
+   genmedia pricing <endpoint_id> --json
+   ```
+
+4. Upload local files once and reuse returned URLs.
+
+   ```bash
+   genmedia upload ./input.png --json
+   genmedia upload ./voiceover.wav --json
+   ```
+
+5. Run each node with JSON output. Use async for slow generation.
+
+   ```bash
+   genmedia run <endpoint_id> --<field> "<value>" --json
+   genmedia run <endpoint_id> --<field> "<value>" --async --json
+   genmedia status <endpoint_id> <request_id> --download "./outputs/workflow/{request_id}_{index}.{ext}" --json
+   ```
+
+6. For downstream nodes, pass the media URL from the previous `result` when it
+   is available. If you only have a local file path, upload it first.
+
+7. Download final assets with templates that cannot collide.
+
+   ```bash
+   --download "./outputs/workflow/{request_id}_{index}.{ext}"
+   ```
+
+8. Return a compact manifest.
+
+   ```json
+   {
+     "goal": "short deliverable description",
+     "nodes": [
+       {
+         "id": "shot_01",
+         "role": "image_to_video",
+         "endpoint_id": "...",
+         "request_id": "...",
+         "input_urls": ["..."],
+         "output_urls": ["..."],
+         "downloaded_files": ["..."],
+         "notes": "continuity or defect notes"
+       }
+     ],
+     "final_files": ["..."]
+   }
+   ```
+
+## Pipeline rules
+
+- Keep one node responsible for one clear transformation.
+- Fan out independent generation, crop, upscale, subtitle, or variation nodes.
+- Keep sequential chains only when node B needs node A output.
+- For consistency, prefer reference/edit or image-to-video over independent
+  text-only generations.
+- For default creative model choices, follow `model-routing` unless the user
+  names a model.
+- Use utility endpoints for deterministic work: crop, resize, grid, composite,
+  audio merge, subtitle, speed change, compression.
+- Record endpoint, schema-relevant parameters, request ID, and output path for
+  every node.
+- If a 422 error occurs, read `validation_errors`, inspect schema again, then
+  fix the exact field.
+
+## Quality gate
+
+Before returning, verify:
+
+- The pipeline graph matches the requested deliverable.
+- No generation model was chosen from memory alone.
+- All local source files were uploaded before use.
+- Final files were saved through `--download`.
+- Utility endpoints used exact schema fields.
+- Continuity anchors were repeated where identity or product fidelity matters.
+- Each node output is either accepted, retried, or marked with a defect.
+
+If the workflow becomes too complex, stop expanding and ask the user to choose
+between faster iteration, higher fidelity, or broader variation.

--- a/skills/workflow/references/node-rules.md
+++ b/skills/workflow/references/node-rules.md
@@ -1,0 +1,84 @@
+# Node rules
+
+## Planner node
+
+- Produces the workflow graph, shot table, or variant matrix.
+- Output must be structured enough to execute without interpretation drift.
+- Include node IDs, dependencies, intended endpoint role, inputs, and expected
+  outputs.
+- Keep creative planning separate from executable parameters.
+
+## Extractor node
+
+- Converts planner output into one narrow prompt, caption, subtitle, filename,
+  or parameter set.
+- Use deterministic wording and low creativity.
+- Prefer split or merge text utilities when the task is simple string
+  manipulation.
+
+## Image generation node
+
+- Choose the endpoint from `model-routing` first.
+- Verify it with `genmedia models --endpoint_id <endpoint_id> --json`.
+- Use free-text `genmedia models "<query>" --json` only when the routed
+  endpoint is missing or the role is not covered.
+- Inspect schema before setting aspect ratio, image size, count, seed, or
+  negative prompt.
+- For grids, describe layout and panel count exactly.
+- For product or character continuity, prefer reference or edit workflows.
+
+## Image editing node
+
+- Upload every source image first.
+- Change one thing per pass.
+- State preservation rules first, edit instruction second.
+- If multiple references are used, assign roles: identity, style, background,
+  product, pose, texture.
+
+## Image-to-video node
+
+- Prefer image-to-video when a reference frame exists.
+- Use short motion prompts, usually 15 to 35 words.
+- Specify subject motion, camera motion, and ambient motion.
+- Avoid describing static composition again unless the schema or model needs it.
+- Run async and download via `genmedia status`.
+
+## Utility node
+
+- Utility work should be deterministic: resize, crop, grid, composite, overlay,
+  subtitle, join audio and video, speed change, split, merge, compress.
+- Always inspect schema because utility endpoints often have exact field names.
+- Use generated result URLs for downstream inputs when available.
+- Use `genmedia upload` for local intermediate files before passing them into
+  another endpoint.
+
+## QA node
+
+Use a manual or vision-based check after high-risk nodes:
+
+- Identity preserved.
+- Product logo and packaging preserved.
+- Crop and aspect ratio correct.
+- Text is absent, intentional, or added by a text utility.
+- Audio and subtitle timing match.
+- Clip order and duration match the plan.
+
+## Manifest node
+
+Return a compact manifest at the end:
+
+```json
+{
+  "node_id": "shot_03_i2v",
+  "role": "image_to_video",
+  "endpoint_id": "selected endpoint",
+  "request_id": "fal request id",
+  "inputs": ["source url or local path"],
+  "outputs": ["result media url"],
+  "downloaded_files": ["local file path"],
+  "status": "accepted | retried | rejected",
+  "notes": "short defect or continuity note"
+}
+```
+
+Keep manifests factual. Do not include promotional copy.

--- a/skills/workflow/references/pipeline-patterns.md
+++ b/skills/workflow/references/pipeline-patterns.md
@@ -1,0 +1,132 @@
+# Pipeline patterns
+
+## Fan-out parallel pipeline
+
+Use for multi-scene video, batches, datasets, and variant exploration.
+
+```text
+planner -> structured plan
+planner -> extract shot 1 -> generate 1 -> utility 1
+planner -> extract shot 2 -> generate 2 -> utility 2
+planner -> extract shot N -> generate N -> utility N
+all outputs -> assembly
+```
+
+Rules:
+
+- Planner output must be structured JSON or clearly delimited text.
+- Independent lanes can run in parallel.
+- Assembly waits until every required lane is complete.
+- Record each lane's request ID and downloaded file.
+
+## Sequential compositing chain
+
+Use when each step must preserve the previous result.
+
+```text
+base scene -> add product -> add person -> add effect -> final image -> video
+```
+
+Rules:
+
+- One edit pass changes one thing.
+- Every edit prompt states what must be preserved.
+- Use the previous result URL as the next input when possible.
+- Check identity, product shape, and lighting before advancing.
+
+## Contact sheet then slice
+
+Use for character poses, product angles, style variants, and dataset panels.
+
+```text
+generate grid -> crop panel 1..N -> upscale panel 1..N -> optional video
+```
+
+Rules:
+
+- Generate panels in one image when consistency matters.
+- Prompt for exact grid layout and no visible borders or gaps.
+- Crop by percentage coordinates if the crop utility expects percentages.
+- Upscale after crop when final quality matters.
+
+## Frame bridging
+
+Use for long continuous videos.
+
+```text
+start image -> clip 1 -> extract last frame -> clip 2 -> extract last frame -> clip N -> merge
+```
+
+Rules:
+
+- The last frame of one clip becomes the start image of the next clip.
+- Motion prompt stays short and physically specific.
+- Keep visual anchors stable across clips.
+- Merge only after all clips pass continuity checks.
+
+## Start/end frame interpolation
+
+Use for precise product reveals, character motion, and controlled transitions.
+
+```text
+start frame -> edit into end frame -> video from start and end
+```
+
+Rules:
+
+- Create the end frame by editing the start frame, not independent generation.
+- Motion prompt describes only the transition.
+- Use degrees, directions, distances, and speed rather than vague movement.
+
+## Multi-modal assembly
+
+Use for narration, music, subtitles, and visual clips.
+
+```text
+scene plan -> narration text -> TTS
+scene plan -> image prompt -> image -> video
+TTS + video -> join audio video
+joined clips -> subtitles -> final assembly
+```
+
+Rules:
+
+- Visual and audio lanes can run in parallel.
+- Merge audio with each scene before final concatenation.
+- Keep voice settings consistent.
+- Disable generated video audio if external TTS is used and schema supports it.
+
+## Multi-expert planning
+
+Use for complex briefs with strategy, art direction, motion, and format
+variation.
+
+```text
+brief -> brand analysis
+brand analysis -> strategist
+brand analysis -> art director
+brand analysis -> motion director
+experts -> master prompt plan -> generation nodes
+```
+
+Rules:
+
+- Each expert output must be structured.
+- Master plan removes repetition across angles, backgrounds, and lighting.
+- This is a planning pattern. Generation still uses discovered genmedia models.
+
+## Systematic variation matrix
+
+Use for product sets, style exploration, character sheets, and A/B testing.
+
+```text
+base prompt + angle A + light A -> output 1
+base prompt + angle B + light A -> output 2
+base prompt + angle A + light B -> output 3
+```
+
+Rules:
+
+- Vary one controlled axis per node when analyzing results.
+- Keep all identity and product constraints identical.
+- Avoid random changes when the user needs comparable outputs.

--- a/skills/workflow/references/recipes.md
+++ b/skills/workflow/references/recipes.md
@@ -1,0 +1,103 @@
+# Workflow recipes
+
+## Multi-scene cinematic video
+
+Input: concept, style, duration, aspect ratio.
+
+```text
+1. Planner creates N scenes with start frame prompt, end frame edit prompt, and motion prompt.
+2. Generate start frames in parallel.
+3. Edit start frames into end frames in parallel.
+4. Run image-to-video for each scene with start and end frames if schema supports it.
+5. Download clips.
+6. Merge clips if a suitable utility endpoint is selected and verified.
+7. Return clip manifest in playback order.
+```
+
+Use `storytelling` and `cinematography` references for shot language.
+
+## Product campaign
+
+Input: product reference, brand tone, deliverables.
+
+```text
+1. Upload product reference.
+2. Generate or edit hero image while preserving product identity.
+3. Create platform variants: square, vertical, wide, PDP.
+4. Create one product reveal clip from the approved hero frame.
+5. Add controlled text only through a utility endpoint or external design step.
+6. Download all assets and return a campaign manifest.
+```
+
+Use `commercial` for product prompt rules.
+
+## Character continuity sequence
+
+Input: approved character reference, scene list.
+
+```text
+1. Use character anchor and uploaded reference.
+2. Generate approved still for each scene or expression.
+3. Run image-to-video per shot from approved stills.
+4. Reject clips with face, hair, wardrobe, or age drift.
+5. Return shot order and local clip paths.
+```
+
+Use `character-design` for anchor and prompt patterns.
+
+## Narrated documentary
+
+Input: topic, runtime, voice direction, visual style.
+
+```text
+1. Planner creates scene table with narration, visual prompt, and duration.
+2. Generate TTS or upload voiceover.
+3. Generate images or clips per scene.
+4. Join each scene's audio and video.
+5. Add subtitles.
+6. Download final scene files or merged output.
+```
+
+Keep narration, subtitles, and visuals aligned by duration.
+
+## Dataset generator
+
+Input: task definition and target count.
+
+```text
+1. Planner creates N diverse prompt pairs.
+2. Generate original images in parallel.
+3. Apply edit or transformation in parallel.
+4. Generate captions or metadata from actual outputs.
+5. Return triplets: original, transformed, caption.
+```
+
+Keep variation controlled and track every seed or schema parameter if used.
+
+## Style exploration
+
+Input: reference asset and target style family.
+
+```text
+1. Build a variation matrix with one changed axis per row.
+2. Run image edit or generation nodes in parallel.
+3. Download all variants.
+4. Return a selection table with style axis, endpoint, output path, and notes.
+```
+
+Use systematic variation before random shotgun variation unless the user asks
+for broad ideation.
+
+## Social media batch
+
+Input: master creative, target platforms.
+
+```text
+1. Generate or choose master asset.
+2. Resize or crop for each platform.
+3. Add platform-safe text externally or through text utility.
+4. Compress for web delivery.
+5. Return outputs grouped by platform and aspect ratio.
+```
+
+Do not rely on generated in-image text for final ad copy.

--- a/skills/workflow/references/utility-endpoints.md
+++ b/skills/workflow/references/utility-endpoints.md
@@ -1,0 +1,95 @@
+# Utility endpoint reference
+
+These are workflow utility candidates from the falgen workflow notes. Verify
+availability with `genmedia models --endpoint_id <id> --json` or search, then
+inspect schema before use.
+
+## Image resize and transform
+
+- `workflowutils/resize-image`: resize to explicit dimensions.
+- `workflowutils/resize-to-max-pixels`: resize while preserving aspect ratio.
+- `workflowutils/crop-image`: crop with percentage-based coordinates.
+- `workflowutils/image-size`: return width and height.
+- `workflow-utilities/compress-image`: compress and optionally resize.
+
+## Image compositing and layout
+
+- `workflowutils/composite-image`: layer images together.
+- `workflow-utilities/overlay-image`: overlay with position, scale, opacity,
+  and stroke.
+- `workflow-utilities/concat-image`: concatenate images horizontally or
+  vertically.
+- `workflow-utilities/image-grid`: create a grid from multiple images.
+- `workflow-utilities/add-text-to-image`: add controlled text after generation.
+
+## Image conversion and masks
+
+- `workflowutils/rgba-to-rgb`: convert transparent image to RGB.
+- `workflow-utilities/split`: split multiple images into individual outputs.
+- `workflow-utilities/merge`: merge multiple images into one output array.
+- `workflowutils/sam-hq`: segmentation masks.
+- `workflowutils/invert_mask`: invert a mask.
+- `workflowutils/blur_mask`: soften mask edges.
+- `workflowutils/grow_mask`: expand mask region.
+- `workflowutils/shrink_mask`: contract mask region.
+- `workflowutils/transparent-image-to_mask`: create a mask from alpha.
+
+## Detection and safety
+
+- `workflowutils/teed`: edge detector.
+- `workflowutils/canny`: Canny edge detector.
+- `workflowutils/image-preprocessors-canny`: alternate Canny endpoint.
+- `workflowutils/face`: face detection or face processing.
+- `workflowutils/brand-checker`: brand detection check.
+- `workflowutils/llm-nsfw-checker`: text safety check.
+
+## Video utilities
+
+- `workflow-utilities/overlay-video`: overlay one video on another.
+- `workflow-utilities/setpts-video`: change playback speed. Keep within
+  schema bounds.
+- `workflow-utilities/add-subtitles-to-video`: add provided subtitles.
+- `workflow-utilities/auto-subtitle`: transcribe and add karaoke-style
+  subtitles.
+- `workflowutils/join-audio-video`: combine audio and video.
+- `workflow-utilities/video-to-gif`: convert video segment to GIF.
+- `workflow-utilities/gif-to-video`: convert GIF to video.
+
+## Audio utilities
+
+- `workflow-utilities/extract-audio`: extract audio from video.
+- `workflow-utilities/split-audio`: split by timestamps.
+- `workflow-utilities/merge-audio`: merge files with optional gaps.
+- `workflow-utilities/amix-audio`: mix streams with weights and normalization.
+
+## Text utilities
+
+- `workflow-utilities/merge-text`: merge strings with a separator.
+- `workflow-utilities/split-text`: split text by delimiter.
+- `workflowutils/text-concat`: concatenate text, prompts, or trigger strings.
+
+## Common utility chains
+
+Background replacement:
+
+```text
+source image -> sam-hq mask -> invert or refine mask -> new background -> composite-image
+```
+
+Social resize:
+
+```text
+master asset -> resize 1:1 -> resize 9:16 -> compress-image
+```
+
+Subtitled video:
+
+```text
+video -> auto-subtitle -> optional setpts-video -> final download
+```
+
+Product catalog:
+
+```text
+product image -> segment -> composite clean background -> image-grid -> compress
+```


### PR DESCRIPTION
## Summary
- Add commercial, character-design, cinematography, storytelling, workflow, and model-routing skill bundles.
- Keep main skills as concise genmedia runbooks with prompt examples and workflow details in references.
- Add endpoint-first routing for production model choices, with text search only as fallback discovery.
- Regenerate skills/index.json for the expanded bundled skill set.

## Validation
- bun run skills:index:check
- bun run typecheck
- bun run check
- git diff --check
