### PR TITLE
feat: optional PostHog analytics for CLI and web routes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,13 @@ jobs:
 
       - name: Build binary
         shell: bash
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
         run: |
           bun run scripts/gen-version.ts
           bun build --compile --minify --bytecode \
             --target=${{ matrix.target }} \
+            --define "__POSTHOG_KEY__=\"${POSTHOG_KEY:-}\"" \
             src/index.ts \
             --outfile dist/${{ matrix.artifact }}
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,30 @@ genmedia update --force      # reinstall even if already on the latest
 
 When automatic updates are enabled (default), every TTY invocation may trigger a rate-limited (1/hour) background check that stages the next release. The next `genmedia` launch atomically swaps it in. Set `GENMEDIA_NO_UPDATE=1` to disable all background checks; the manual `update` command still works.
 
+## Analytics
+
+Released binaries report anonymous usage analytics (PostHog) to help us prioritize improvements. Each install gets a random UUID stored in `~/.genmedia/config.json`; we never collect command arguments, prompts, file paths, API keys, or error messages.
+
+**Events:**
+
+- `command_run` — top-level command name, success/failure, duration
+- `cli_first_run` — fired once when the install is first seen
+- `setup_completed` — `setup` finished successfully
+- `model_run` — `run` finished, with the model endpoint, success/failure, and duration (no inputs or outputs)
+- `skills_searched` — `skills list [query]` — the query string and result count
+- `skills_installed` / `skills_updated` / `skills_removed` — skill name and status
+- `update_applied` — self-update succeeded, with from/to versions
+
+**Opt out:**
+
+```bash
+export GENMEDIA_NO_ANALYTICS=1            # per-shell
+# or persist in config:
+genmedia setup    # (toggle is currently file-only — set "analyticsOptOut": true)
+```
+
+Builds from source without a `POSTHOG_KEY` environment variable (the open-source default) report nothing — the analytics module no-ops at runtime.
+
 ### `init` — Install the default genmedia skill bundle
 
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "citty": "^0.2.2",
         "dotenv": "^17.4.2",
         "ora": "^9.4.0",
+        "posthog-node": "^4.18.0",
         "prompts": "^2.4.2",
       },
       "devDependencies": {
@@ -39,7 +40,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.7", "https://registry.npmjs.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz", { "os": "win32", "cpu": "x64" }, "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ=="],
 
-    "@fal-ai/client": ["@fal-ai/client@1.10.0", "", { "dependencies": { "@msgpack/msgpack": "^3.0.0-beta2", "eventsource-parser": "^1.1.2", "robot3": "^0.4.1" } }, "sha512-sQWnBc6cdIzK8nFybrVKal0rLeJS2vqrrNxx4Hcc0SorndkfkMXL3TIAiIfiF/AlZuVoRpazpNg6n8K81WHzOQ=="],
+    "@fal-ai/client": ["@fal-ai/client@1.10.0", "https://registry.npmjs.com/@fal-ai/client/-/client-1.10.0.tgz", { "dependencies": { "@msgpack/msgpack": "^3.0.0-beta2", "eventsource-parser": "^1.1.2", "robot3": "^0.4.1" } }, "sha512-sQWnBc6cdIzK8nFybrVKal0rLeJS2vqrrNxx4Hcc0SorndkfkMXL3TIAiIfiF/AlZuVoRpazpNg6n8K81WHzOQ=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "https://registry.npmjs.com/@msgpack/msgpack/-/msgpack-3.1.3.tgz", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
@@ -47,21 +48,59 @@
 
     "ansi-regex": ["ansi-regex@6.2.2", "https://registry.npmjs.com/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
+
     "bun-types": ["bun-types@1.3.10", "https://registry.npmjs.com/bun-types/-/bun-types-1.3.10.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "chalk": ["chalk@5.6.2", "https://registry.npmjs.com/chalk/-/chalk-5.6.2.tgz", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
+    "citty": ["citty@0.2.2", "https://registry.npmjs.com/citty/-/citty-0.2.2.tgz", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "https://registry.npmjs.com/cli-cursor/-/cli-cursor-5.0.0.tgz", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-spinners": ["cli-spinners@3.4.0", "https://registry.npmjs.com/cli-spinners/-/cli-spinners-3.4.0.tgz", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
 
-    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dotenv": ["dotenv@17.4.2", "https://registry.npmjs.com/dotenv/-/dotenv-17.4.2.tgz", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "eventsource-parser": ["eventsource-parser@1.1.2", "https://registry.npmjs.com/eventsource-parser/-/eventsource-parser-1.1.2.tgz", {}, "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "https://registry.npmjs.com/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "husky": ["husky@9.1.7", "https://registry.npmjs.com/husky/-/husky-9.1.7.tgz", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
@@ -73,13 +112,23 @@
 
     "log-symbols": ["log-symbols@7.0.1", "https://registry.npmjs.com/log-symbols/-/log-symbols-7.0.1.tgz", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "mimic-function": ["mimic-function@5.0.1", "https://registry.npmjs.com/mimic-function/-/mimic-function-5.0.1.tgz", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "onetime": ["onetime@7.0.0", "https://registry.npmjs.com/onetime/-/onetime-7.0.0.tgz", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
-    "ora": ["ora@9.4.0", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ=="],
+    "ora": ["ora@9.4.0", "https://registry.npmjs.com/ora/-/ora-9.4.0.tgz", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.2", "string-width": "^8.1.0" } }, "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ=="],
+
+    "posthog-node": ["posthog-node@4.18.0", "", { "dependencies": { "axios": "^1.8.2" } }, "sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw=="],
 
     "prompts": ["prompts@2.4.2", "https://registry.npmjs.com/prompts/-/prompts-2.4.2.tgz", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "https://registry.npmjs.com/restore-cursor/-/restore-cursor-5.1.0.tgz", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
@@ -89,7 +138,7 @@
 
     "sisteransi": ["sisteransi@1.0.5", "https://registry.npmjs.com/sisteransi/-/sisteransi-1.0.5.tgz", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
-    "stdin-discarder": ["stdin-discarder@0.3.2", "", {}, "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A=="],
+    "stdin-discarder": ["stdin-discarder@0.3.2", "https://registry.npmjs.com/stdin-discarder/-/stdin-discarder-0.3.2.tgz", {}, "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A=="],
 
     "string-width": ["string-width@8.2.0", "https://registry.npmjs.com/string-width/-/string-width-8.2.0.tgz", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fal-ai/genmedia-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Agent-first CLI for fal.ai — search, run, and manage 600+ generative AI models",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "genmedia": "./dist/genmedia"
   },
   "scripts": {
-    "build": "bun run scripts/gen-version.ts && bun build --compile --minify --bytecode src/index.ts --outfile dist/genmedia",
+    "build": "bun run scripts/gen-version.ts && bun build --compile --minify --bytecode --define __POSTHOG_KEY__=\"\\\"${POSTHOG_KEY:-}\\\"\" src/index.ts --outfile dist/genmedia",
     "dev": "bun run src/index.ts",
     "web:dev": "cd web && bun run dev",
     "web:build": "cd web && bun run build",
@@ -34,6 +34,7 @@
     "citty": "^0.2.2",
     "dotenv": "^17.4.2",
     "ora": "^9.4.0",
+    "posthog-node": "^4.18.0",
     "prompts": "^2.4.2"
   },
   "devDependencies": {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { track } from "../lib/analytics";
 import { isJsonOutput, output } from "../lib/output";
 import { getIndex, installSkill } from "../lib/skills-install";
 import { resolveSkillsBase } from "../lib/skills-registry";
@@ -41,6 +42,12 @@ export default defineCommand({
         name,
         status: result.status,
         installedDir: result.installedDir,
+      });
+      track("skills_installed", {
+        name,
+        status: result.status,
+        force: Boolean(args.force),
+        source: "init",
       });
     }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,6 @@
 import { fal } from "@fal-ai/client";
 import { defineCommand } from "citty";
+import { track } from "../lib/analytics";
 import { configureSDK } from "../lib/api";
 import {
   downloadMedia,
@@ -76,17 +77,36 @@ export default defineCommand({
       }
     }
 
+    const modelStart = performance.now();
+
     if (args.async) {
-      const result = await fal.queue.submit(endpointId, { input });
-      output(
-        {
-          status: "submitted",
-          request_id: result.request_id,
-          endpoint_id: endpointId,
-          hint: `Check status: genmedia status ${endpointId} ${result.request_id}`,
-        },
-        { view: "run" },
-      );
+      try {
+        const result = await fal.queue.submit(endpointId, { input });
+        track("model_run", {
+          endpointId,
+          mode: "async",
+          ok: true,
+          durationMs: Math.round(performance.now() - modelStart),
+        });
+        output(
+          {
+            status: "submitted",
+            request_id: result.request_id,
+            endpoint_id: endpointId,
+            hint: `Check status: genmedia status ${endpointId} ${result.request_id}`,
+          },
+          { view: "run" },
+        );
+      } catch (submitErr) {
+        track("model_run", {
+          endpointId,
+          mode: "async",
+          ok: false,
+          durationMs: Math.round(performance.now() - modelStart),
+          errorClass: (submitErr as Error)?.constructor?.name ?? "Error",
+        });
+        throw submitErr;
+      }
       return;
     }
 
@@ -130,6 +150,12 @@ export default defineCommand({
       });
 
       requestId = result.requestId;
+      track("model_run", {
+        endpointId,
+        mode: "subscribe",
+        ok: true,
+        durationMs: Math.round(performance.now() - modelStart),
+      });
       spinner?.succeed(`Run completed (${result.requestId})`);
 
       let downloaded: Awaited<ReturnType<typeof downloadMedia>> | undefined;
@@ -178,8 +204,16 @@ export default defineCommand({
         { view: "run", showLogs },
       );
     } catch (runError) {
-      spinner?.fail(requestId ? `Run failed (${requestId})` : "Run failed");
       const formatted = formatApiError(runError, "Run failed");
+      track("model_run", {
+        endpointId,
+        mode: "subscribe",
+        ok: false,
+        durationMs: Math.round(performance.now() - modelStart),
+        errorClass:
+          formatted.name ?? (runError as Error)?.constructor?.name ?? "Error",
+      });
+      spinner?.fail(requestId ? `Run failed (${requestId})` : "Run failed");
       error(
         formatted.message,
         {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { track } from "../lib/analytics";
 import {
   CONFIG_DIR,
   type GenmediaConfig,
@@ -133,6 +134,7 @@ async function runNonInteractive(args: Record<string, unknown>): Promise<void> {
   }
 
   saveConfig(next);
+  track("setup_completed", { interactive: false });
   output(summaryPayload(next));
 }
 
@@ -253,6 +255,7 @@ async function runInteractive(): Promise<void> {
     };
 
     saveConfig(config);
+    track("setup_completed", { interactive: true });
 
     printLine();
     printLine(

--- a/src/commands/skills/install.ts
+++ b/src/commands/skills/install.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { track } from "../../lib/analytics";
 import { isJsonOutput, output } from "../../lib/output";
 import { installSkill } from "../../lib/skills-install";
 import { colors } from "../../lib/ui";
@@ -21,6 +22,12 @@ export default defineCommand({
   },
   async run({ args }) {
     const result = await installSkill(process.cwd(), args.name, {
+      force: Boolean(args.force),
+    });
+
+    track("skills_installed", {
+      name: args.name,
+      status: result.status,
       force: Boolean(args.force),
     });
 

--- a/src/commands/skills/list.ts
+++ b/src/commands/skills/list.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { track } from "../../lib/analytics";
 import { error, isJsonOutput, output } from "../../lib/output";
 import {
   getSkillsApiUrl,
@@ -29,6 +30,7 @@ export default defineCommand({
     try {
       result = await searchSkillsApi(query);
     } catch (e) {
+      track("skills_searched", { query, ok: false });
       error(`Failed to fetch skills registry`, {
         url: `${getSkillsApiUrl()}${query ? `?q=${encodeURIComponent(query)}` : ""}`,
         message: (e as Error).message,
@@ -42,6 +44,12 @@ export default defineCommand({
       installed: installedNames.has(s.name),
       score: s.score,
     }));
+
+    track("skills_searched", {
+      query,
+      ok: true,
+      resultCount: skills.length,
+    });
 
     if (isJsonOutput()) {
       output({

--- a/src/commands/skills/remove.ts
+++ b/src/commands/skills/remove.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { track } from "../../lib/analytics";
 import { isJsonOutput, output } from "../../lib/output";
 import { uninstallSkill } from "../../lib/skills-install";
 import { colors, symbols } from "../../lib/ui";
@@ -17,6 +18,8 @@ export default defineCommand({
   },
   async run({ args }) {
     const { removed, installedDir } = uninstallSkill(process.cwd(), args.name);
+
+    track("skills_removed", { name: args.name, removed });
 
     if (isJsonOutput()) {
       output({ name: args.name, removed, installedDir });

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import { track } from "../../lib/analytics";
 import { isJsonOutput, output } from "../../lib/output";
 import { getIndex, installSkill } from "../../lib/skills-install";
 import { readInstalledManifest } from "../../lib/skills-registry";
@@ -43,6 +44,7 @@ export default defineCommand({
         sharedIndex: index,
       });
       updated.push({ name, status: result.status });
+      track("skills_updated", { name, status: result.status });
     }
 
     if (isJsonOutput()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { type CommandDef, defineCommand, renderUsage, runMain } from "citty";
+import { initAnalytics, shutdownAnalytics, track } from "./lib/analytics";
 import { renderBanner } from "./lib/banner";
 import { loadConfig } from "./lib/config";
 import { loadDotEnv } from "./lib/env";
@@ -16,6 +17,30 @@ import {
 } from "./lib/updater";
 import { VERSION } from "./lib/version";
 
+const KNOWN_COMMANDS = new Set([
+  "setup",
+  "init",
+  "skills",
+  "models",
+  "schema",
+  "run",
+  "status",
+  "upload",
+  "pricing",
+  "docs",
+  "version",
+  "update",
+]);
+
+function sanitizeCommandName(arg: string | undefined): string {
+  if (!arg) return "(root)";
+  if (arg === "--help" || arg === "-h") return "(help)";
+  if (arg === "--version") return "version";
+  if (arg === "--json") return "(root)";
+  if (KNOWN_COMMANDS.has(arg)) return arg;
+  return "(unknown)";
+}
+
 preSwapPendingUpdate();
 
 // Internal entrypoint used by the background auto-update subprocess.
@@ -23,11 +48,12 @@ preSwapPendingUpdate();
 if (process.argv[2] === "__update-check") {
   runBackgroundUpdateCheck().finally(() => process.exit(0));
 } else {
-  startCli();
+  void startCli();
 }
 
-function startCli(): void {
+async function startCli(): Promise<void> {
   loadDotEnv();
+  initAnalytics();
   maybeTriggerBackgroundUpdate();
 
   // JSON help schema for agents — output before citty intercepts --help
@@ -44,6 +70,8 @@ function startCli(): void {
       env: {
         FAL_KEY:
           "Your fal.ai API key. Can also be set via `genmedia setup` (interactive) or `genmedia setup --non-interactive --api-key <key>` (for agents/CI). Get one at https://fal.ai/dashboard/keys",
+        GENMEDIA_NO_ANALYTICS:
+          "Set to 1 to disable anonymous usage analytics (also configurable via `analyticsOptOut: true` in ~/.genmedia/config.json)",
       },
       commands: {
         models: {
@@ -181,6 +209,8 @@ function startCli(): void {
         },
       },
     });
+    track("command_run", { name: "(json-help)", ok: true, durationMs: 0 });
+    await shutdownAnalytics();
     process.exit(0);
   }
 
@@ -221,31 +251,53 @@ function startCli(): void {
     },
   });
 
-  runMain(main, {
-    showUsage: async (cmd, parent) => {
-      const anyCmd = cmd as CommandDef;
-      const anyParent = parent as CommandDef | undefined;
-      if (isDynamicRunCommand(anyCmd) && isJsonOutput()) {
-        outputRawJson(await renderDynamicRunUsageJson(anyCmd, anyParent));
-        return;
-      }
-      if (process.stdout.isTTY) {
-        console.log(renderBanner(VERSION, "small"));
-      }
-      const usage = isDynamicRunCommand(anyCmd)
-        ? await renderDynamicRunUsage(anyCmd, anyParent)
-        : await renderUsage(cmd, parent);
-      console.log(`${usage}\n`);
+  const commandName = sanitizeCommandName(process.argv[2]);
+  const commandStart = performance.now();
+  let tracked = false;
+  const fireCommandRun = (ok: boolean, errorClass?: string): void => {
+    if (tracked) return;
+    tracked = true;
+    track("command_run", {
+      name: commandName,
+      ok,
+      durationMs: Math.round(performance.now() - commandStart),
+      ...(errorClass ? { errorClass } : {}),
+    });
+  };
 
-      if (!isJsonOutput() && !process.env.FAL_KEY && !loadConfig().apiKey) {
-        console.log(
-          "Tip: set FAL_KEY in your environment or run `genmedia setup` before using model commands.",
-        );
-        console.log(
-          '     For agents/CI: `genmedia setup --non-interactive --api-key "$FAL_KEY"`.',
-        );
-        console.log();
-      }
-    },
-  });
+  try {
+    await runMain(main, {
+      showUsage: async (cmd, parent) => {
+        const anyCmd = cmd as CommandDef;
+        const anyParent = parent as CommandDef | undefined;
+        if (isDynamicRunCommand(anyCmd) && isJsonOutput()) {
+          outputRawJson(await renderDynamicRunUsageJson(anyCmd, anyParent));
+          return;
+        }
+        if (process.stdout.isTTY) {
+          console.log(renderBanner(VERSION, "small"));
+        }
+        const usage = isDynamicRunCommand(anyCmd)
+          ? await renderDynamicRunUsage(anyCmd, anyParent)
+          : await renderUsage(cmd, parent);
+        console.log(`${usage}\n`);
+
+        if (!isJsonOutput() && !process.env.FAL_KEY && !loadConfig().apiKey) {
+          console.log(
+            "Tip: set FAL_KEY in your environment or run `genmedia setup` before using model commands.",
+          );
+          console.log(
+            '     For agents/CI: `genmedia setup --non-interactive --api-key "$FAL_KEY"`.',
+          );
+          console.log();
+        }
+      },
+    });
+    fireCommandRun(true);
+  } catch (err) {
+    fireCommandRun(false, (err as Error)?.constructor?.name ?? "Error");
+    throw err;
+  } finally {
+    await shutdownAnalytics();
+  }
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,114 @@
+import { getOrCreateInstallationId, loadConfig } from "./config";
+import { getOutputMode } from "./output";
+import { VERSION } from "./version";
+
+// Replaced at build time by `bun build --define __POSTHOG_KEY__='"phc_xxx"'`.
+// Empty string (or undefined in `bun run dev`) disables analytics entirely.
+declare const __POSTHOG_KEY__: string | undefined;
+
+const POSTHOG_HOST = "https://us.i.posthog.com";
+
+type PostHogClient = {
+  capture: (args: {
+    distinctId: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  }) => void;
+  shutdown: () => Promise<void>;
+};
+
+let _enabled = false;
+let _client: PostHogClient | null = null;
+let _distinctId: string | null = null;
+let _superProps: Record<string, unknown> = {};
+let _initPromise: Promise<void> | null = null;
+let _firstRun = false;
+
+function resolveKey(): string {
+  const buildTimeKey =
+    typeof __POSTHOG_KEY__ !== "undefined" ? __POSTHOG_KEY__ : undefined;
+  return (buildTimeKey ?? process.env.POSTHOG_KEY ?? "").trim();
+}
+
+function isOptedOut(): boolean {
+  if (process.env.GENMEDIA_NO_ANALYTICS === "1") return true;
+  if (loadConfig().analyticsOptOut === true) return true;
+  return false;
+}
+
+export function initAnalytics(): void {
+  if (_initPromise) return;
+  _initPromise = (async () => {
+    try {
+      const key = resolveKey();
+      if (!key || isOptedOut()) return;
+
+      const cfg = loadConfig();
+      _firstRun = !cfg.installationId;
+      _distinctId = getOrCreateInstallationId();
+
+      const { PostHog } = await import("posthog-node");
+      _client = new PostHog(key, {
+        host: POSTHOG_HOST,
+        flushAt: 1,
+        flushInterval: 0,
+      }) as unknown as PostHogClient;
+
+      _superProps = {
+        version: VERSION,
+        platform: process.platform,
+        arch: process.arch,
+        runtime: process.versions.bun
+          ? `bun-${process.versions.bun}`
+          : `node-${process.version}`,
+        outputMode: getOutputMode(),
+      };
+
+      _enabled = true;
+
+      if (_firstRun) {
+        track("cli_first_run");
+      }
+    } catch {
+      // Analytics must never break the CLI.
+    }
+  })();
+}
+
+export function track(
+  event: string,
+  properties: Record<string, unknown> = {},
+): void {
+  if (!_enabled || !_client || !_distinctId) return;
+  try {
+    _client.capture({
+      distinctId: _distinctId,
+      event,
+      properties: { ..._superProps, ...properties },
+    });
+  } catch {
+    // Swallow — analytics must never throw.
+  }
+}
+
+export async function shutdownAnalytics(): Promise<void> {
+  if (!_initPromise) return;
+  try {
+    await _initPromise;
+  } catch {
+    return;
+  }
+  if (!_enabled || !_client) return;
+
+  try {
+    await Promise.race([
+      _client.shutdown(),
+      new Promise<void>((resolve) => setTimeout(resolve, 500)),
+    ]);
+  } catch {
+    // ignore
+  } finally {
+    _enabled = false;
+    _client = null;
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ import {
   createDecipheriv,
   createHash,
   randomBytes,
+  randomUUID,
 } from "node:crypto";
 import {
   chmodSync,
@@ -24,6 +25,8 @@ export interface GenmediaConfig {
   autoUpdate?: boolean;
   lastUpdateCheckAt?: number;
   latestKnownVersion?: string;
+  installationId?: string;
+  analyticsOptOut?: boolean;
 }
 
 // On-disk representation — apiKey is stored encrypted, never plaintext
@@ -34,6 +37,8 @@ interface StoredConfig {
   autoUpdate?: boolean;
   lastUpdateCheckAt?: number;
   latestKnownVersion?: string;
+  installationId?: string;
+  analyticsOptOut?: boolean;
 }
 
 export const CONFIG_DIR = join(userInfo().homedir, ".genmedia");
@@ -91,6 +96,8 @@ export function loadConfig(): GenmediaConfig {
         autoUpdate: stored.autoUpdate,
         lastUpdateCheckAt: stored.lastUpdateCheckAt,
         latestKnownVersion: stored.latestKnownVersion,
+        installationId: stored.installationId,
+        analyticsOptOut: stored.analyticsOptOut,
         ...(stored.apiKey
           ? { apiKey: decryptApiKey(stored.apiKey) ?? undefined }
           : {}),
@@ -114,6 +121,8 @@ export function saveConfig(config: GenmediaConfig): void {
     autoUpdate: config.autoUpdate,
     lastUpdateCheckAt: config.lastUpdateCheckAt,
     latestKnownVersion: config.latestKnownVersion,
+    installationId: config.installationId,
+    analyticsOptOut: config.analyticsOptOut,
     ...(config.apiKey ? { apiKey: encryptApiKey(config.apiKey) } : {}),
   };
   writeFileSync(CONFIG_FILE, JSON.stringify(stored, null, 2), "utf-8");
@@ -124,4 +133,15 @@ export function saveConfig(config: GenmediaConfig): void {
     // Windows — permissions work differently, not an error
   }
   _cached = config;
+}
+
+// Returns the persistent installation ID. Generates one on first call and
+// persists it to the config file. Used as the PostHog distinct_id and any
+// other anonymous-but-stable identifier the CLI needs.
+export function getOrCreateInstallationId(): string {
+  const cfg = loadConfig();
+  if (cfg.installationId) return cfg.installationId;
+  const id = randomUUID();
+  saveConfig({ ...cfg, installationId: id });
+  return id;
 }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -10,6 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
+import { track } from "./analytics";
 import { loadConfig, saveConfig } from "./config";
 import { VERSION } from "./version";
 
@@ -333,5 +334,6 @@ export async function runManualUpdate(opts: {
   }
 
   result.updated = true;
+  track("update_applied", { from: VERSION, to: latest });
   return result;
 }

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -3,3 +3,7 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## Analytics
+
+Server-side analytics (`web/lib/analytics.ts`) capture anonymous events on the API routes (install-script downloads, skill searches). They no-op when `POSTHOG_KEY` is unset. In Vercel, set `POSTHOG_KEY` in project settings (Production + Preview); locally, leave it unset or export it in your shell to test.

--- a/web/app/install.ps1/route.ts
+++ b/web/app/install.ps1/route.ts
@@ -1,5 +1,6 @@
+import type { NextRequest } from "next/server";
 import { serveInstallScript } from "@/lib/install";
 
-export async function GET() {
-  return serveInstallScript("ps1");
+export async function GET(request: NextRequest) {
+  return serveInstallScript("ps1", request.headers.get("user-agent"));
 }

--- a/web/app/install.sh/route.ts
+++ b/web/app/install.sh/route.ts
@@ -1,5 +1,6 @@
+import type { NextRequest } from "next/server";
 import { serveInstallScript } from "@/lib/install";
 
-export async function GET() {
-  return serveInstallScript("sh");
+export async function GET(request: NextRequest) {
+  return serveInstallScript("sh", request.headers.get("user-agent"));
 }

--- a/web/app/install/route.ts
+++ b/web/app/install/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from "next/server";
 import { detectPlatform, serveInstallScript } from "@/lib/install";
 
 export async function GET(request: NextRequest) {
-  const platform = detectPlatform(request.headers.get("user-agent"));
-  return serveInstallScript(platform);
+  const userAgent = request.headers.get("user-agent");
+  const platform = detectPlatform(userAgent);
+  return serveInstallScript(platform, userAgent);
 }

--- a/web/app/skills/route.ts
+++ b/web/app/skills/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import { trackServer } from "@/lib/analytics";
 import {
   fetchSkillsIndex,
   getRegistryUrl,
@@ -16,6 +17,7 @@ export async function GET(request: NextRequest) {
   try {
     index = await fetchSkillsIndex();
   } catch (err) {
+    trackServer("skills_searched", { query, ok: false });
     return Response.json(
       {
         error: "skills registry unavailable",
@@ -31,6 +33,13 @@ export async function GET(request: NextRequest) {
     limit && Number.isFinite(limit) && limit > 0
       ? matches.slice(0, limit)
       : matches;
+
+  trackServer("skills_searched", {
+    query,
+    ok: true,
+    resultCount: skills.length,
+    totalSkills: index.skills.length,
+  });
 
   return Response.json(
     {

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "minisearch": "^7.2.0",
         "next": "16.2.4",
+        "posthog-node": "^4.18.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
       },
@@ -100,17 +101,61 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "https://registry.npmjs.com/@types/react-dom/-/react-dom-19.2.3.tgz", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "https://registry.npmjs.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001788", "https://registry.npmjs.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
 
     "client-only": ["client-only@0.0.1", "https://registry.npmjs.com/client-only/-/client-only-0.0.1.tgz", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "csstype": ["csstype@3.2.3", "https://registry.npmjs.com/csstype/-/csstype-3.2.3.tgz", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "https://registry.npmjs.com/detect-libc/-/detect-libc-2.1.2.tgz", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "minisearch": ["minisearch@7.2.0", "https://registry.npmjs.com/minisearch/-/minisearch-7.2.0.tgz", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
 
     "nanoid": ["nanoid@3.3.11", "https://registry.npmjs.com/nanoid/-/nanoid-3.3.11.tgz", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -119,6 +164,10 @@
     "picocolors": ["picocolors@1.1.1", "https://registry.npmjs.com/picocolors/-/picocolors-1.1.1.tgz", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "postcss": ["postcss@8.4.31", "https://registry.npmjs.com/postcss/-/postcss-8.4.31.tgz", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "posthog-node": ["posthog-node@4.18.0", "", { "dependencies": { "axios": "^1.8.2" } }, "sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw=="],
+
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "react": ["react@19.2.4", "https://registry.npmjs.com/react/-/react-19.2.4.tgz", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 

--- a/web/lib/analytics.ts
+++ b/web/lib/analytics.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from "node:crypto";
+import { PostHog } from "posthog-node";
+
+const POSTHOG_HOST = "https://us.i.posthog.com";
+
+const key = process.env.POSTHOG_KEY?.trim() ?? "";
+
+const client: PostHog | null = key
+  ? new PostHog(key, {
+      host: POSTHOG_HOST,
+      flushAt: 1,
+      flushInterval: 0,
+    })
+  : null;
+
+// Server-side analytics are anonymous: each request gets a synthetic
+// distinctId so we never persist user identifiers. Web-side events are
+// not (yet) correlated with CLI installation IDs.
+export function trackServer(
+  event: string,
+  properties: Record<string, unknown> = {},
+  distinctId?: string,
+): void {
+  if (!client) return;
+  try {
+    client.capture({
+      distinctId: distinctId ?? `anon-${randomUUID()}`,
+      event,
+      properties,
+    });
+  } catch {
+    // Analytics must never break a route handler.
+  }
+}

--- a/web/lib/install.ts
+++ b/web/lib/install.ts
@@ -1,3 +1,5 @@
+import { trackServer } from "./analytics";
+
 export const INSTALL_SH =
   "https://raw.githubusercontent.com/fal-ai-community/genmedia-cli/refs/heads/main/install.sh";
 export const INSTALL_PS1 =
@@ -13,16 +15,29 @@ export function detectPlatform(userAgent: string | null): Platform {
 
 export async function serveInstallScript(
   platform: Platform,
+  userAgent: string | null = null,
 ): Promise<Response> {
   const url = platform === "ps1" ? INSTALL_PS1 : INSTALL_SH;
   const upstream = await fetch(url, { cache: "no-store" });
+  const ua = userAgent ?? "";
 
   if (!upstream.ok) {
+    trackServer("install_script_served", {
+      platform,
+      ok: false,
+      userAgent: ua,
+    });
     return new Response("install script unavailable\n", {
       status: 502,
       headers: { "content-type": "text/plain; charset=utf-8" },
     });
   }
+
+  trackServer("install_script_served", {
+    platform,
+    ok: true,
+    userAgent: ua,
+  });
 
   return new Response(upstream.body, {
     status: 200,

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "minisearch": "^7.2.0",
     "next": "16.2.4",
+    "posthog-node": "^4.18.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },


### PR DESCRIPTION
## Summary

Adds anonymous usage analytics (PostHog) to the CLI and the web app's API routes. Designed so the open-source repo can be built and run without any keys — analytics no-op cleanly.

- **CLI key injection at build time** via `bun build --define __POSTHOG_KEY__=...`. CI passes `secrets.POSTHOG_KEY` (set in repo settings); local builds without the env var produce binaries with analytics disabled.
- **Web key at runtime** via `process.env.POSTHOG_KEY`. Set in Vercel project settings (Production + Preview); unset = no-op.
- **Opt-out**: `GENMEDIA_NO_ANALYTICS=1` env var or `analyticsOptOut: true` in `~/.genmedia/config.json` (mirrors `GENMEDIA_NO_UPDATE`).
- **Distinct ID**: a UUID generated and persisted to `~/.genmedia/config.json` on first run; sent as PostHog `distinctId`. Web events use a per-request synthetic ID — anonymous.

### Events

CLI:
- `command_run` — sanitized command name (whitelist), `ok`, `durationMs`, `errorClass?`
- `cli_first_run` — fired once on first install
- `setup_completed` — `interactive` flag
- `model_run` — `endpointId`, `mode` (`async`/`subscribe`), `ok`, `durationMs`, `errorClass?`
- `skills_searched` — `query`, `ok`, `resultCount`
- `skills_installed` / `skills_updated` / `skills_removed` — `name`, `status`/`removed`
- `update_applied` — `from`, `to` versions

Web:
- `install_script_served` — `platform`, `ok`, `userAgent`
- `skills_searched` — `query`, `ok`, `resultCount`, `totalSkills`

### Privacy

No argv, no prompts, no inputs/outputs, no file paths, no API keys, no error messages. Skill names and search queries are public registry identifiers and are captured intentionally. User-agent on install routes is captured to break down install flows by OS/shell.

### Required follow-up (not in this PR)

- Add `POSTHOG_KEY` repository secret on GitHub.
- Add `POSTHOG_KEY` env var to the Vercel web project (Production + Preview).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run check` clean (biome)
- [x] `bun run build` succeeds with no `POSTHOG_KEY` (no `phc_*` strings in binary)
- [x] `POSTHOG_KEY=phc_test bun run build` bakes the key into the binary
- [x] `bun run web:build` succeeds
- [x] Privacy audit: every `track`/`trackServer` call site reviewed — only safe metadata
- [ ] Verify a real release build produces events in PostHog after `secrets.POSTHOG_KEY` is added
- [ ] Verify Vercel deploy emits `install_script_served` and `skills_searched` after env var is added