### PR TITLE
feat: fan `init` out to Claude, Cursor, and AGENTS.md targets

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import type { AgentTargetKind, TargetOptions } from "../lib/agent-targets";
 import { track } from "../lib/analytics";
 import { isJsonOutput, output } from "../lib/output";
 import { getIndex, installSkill } from "../lib/skills-install";
@@ -6,6 +7,39 @@ import { resolveSkillsBase } from "../lib/skills-registry";
 import { colors, createSpinner, symbols } from "../lib/ui";
 
 const DEFAULT_BUNDLE = ["genmedia"];
+
+const VALID_TARGETS: readonly AgentTargetKind[] = [
+  "claude",
+  "cursor",
+  "agents-md",
+];
+
+function parseTargetsFlag(
+  raw: string | undefined,
+): AgentTargetKind[] | undefined {
+  if (!raw) return undefined;
+  const parts = raw
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean) as AgentTargetKind[];
+  for (const p of parts) {
+    if (!VALID_TARGETS.includes(p)) {
+      throw new Error(
+        `Unknown target '${p}'. Valid targets: ${VALID_TARGETS.join(", ")}`,
+      );
+    }
+  }
+  return parts;
+}
+
+function buildTargetOptions(args: Record<string, unknown>): TargetOptions {
+  const exclude: AgentTargetKind[] = [];
+  if (args.claude === false) exclude.push("claude");
+  if (args.cursor === false) exclude.push("cursor");
+  if (args["agents-md"] === false) exclude.push("agents-md");
+  const only = parseTargetsFlag(args.targets as string | undefined);
+  return { only, exclude: exclude.length ? exclude : undefined };
+}
 
 export default defineCommand({
   meta: {
@@ -18,36 +52,54 @@ export default defineCommand({
       type: "boolean",
       description: "Reinstall even if the skills are already present",
     },
+    targets: {
+      type: "string",
+      description:
+        "Comma-separated list of agent targets (claude, cursor, agents-md). Default: all.",
+    },
+    claude: {
+      type: "boolean",
+      default: true,
+      description:
+        "Write to .claude/skills/ (or .agents/skills/). Use --no-claude to skip.",
+    },
+    cursor: {
+      type: "boolean",
+      default: true,
+      description:
+        "Write the Cursor rule (.cursor/rules/<name>.mdc). Use --no-cursor to skip.",
+    },
+    "agents-md": {
+      type: "boolean",
+      default: true,
+      description:
+        "Append a fenced block to AGENTS.md. Use --no-agents-md to skip.",
+    },
   },
   async run({ args }) {
     const cwd = process.cwd();
+    const targetOptions = buildTargetOptions(args as Record<string, unknown>);
     const spinner = createSpinner("Fetching registry…");
     spinner.start();
 
     const index = await getIndex();
     spinner.update("Installing default skills…");
 
-    const results: Array<{
-      name: string;
-      status: string;
-      installedDir: string;
-    }> = [];
+    const results = [];
     for (const name of DEFAULT_BUNDLE) {
       const result = await installSkill(cwd, name, {
         force: Boolean(args.force),
         sharedIndex: index,
         spinner,
+        targetOptions,
       });
-      results.push({
-        name,
-        status: result.status,
-        installedDir: result.installedDir,
-      });
+      results.push(result);
       track("skills_installed", {
         name,
         status: result.status,
         force: Boolean(args.force),
         source: "init",
+        targets: result.targets.map((t) => t.kind),
       });
     }
 
@@ -56,7 +108,15 @@ export default defineCommand({
     const skillsBase = resolveSkillsBase(cwd);
 
     if (isJsonOutput()) {
-      output({ skills: results, skillsDir: skillsBase });
+      output({
+        skills: results.map((r) => ({
+          name: r.name,
+          status: r.status,
+          installedDir: r.installedDir,
+          targets: r.targets,
+        })),
+        skillsDir: skillsBase,
+      });
       return;
     }
 
@@ -69,13 +129,16 @@ export default defineCommand({
       process.stdout.write(
         `  ${icon} ${colors.bold(r.name)}  ${colors.dim(r.status)}\n`,
       );
+      for (const t of r.targets) {
+        for (const p of t.paths) {
+          process.stdout.write(`      ${colors.dim(`→ ${t.kind}: ${p}`)}\n`);
+        }
+      }
     }
-    if (skillsBase) {
-      process.stdout.write(
-        `\n${colors.dim(`Tip: commit ${skillsBase}/ so teammates get the same skills.`)}\n\n`,
-      );
-    } else {
-      process.stdout.write("\n");
-    }
+    process.stdout.write(
+      `\n${colors.dim(
+        `Tip: commit the written files so teammates and AI agents pick up the same skills.`,
+      )}\n\n`,
+    );
   },
 });

--- a/src/commands/skills/install.ts
+++ b/src/commands/skills/install.ts
@@ -1,8 +1,42 @@
 import { defineCommand } from "citty";
+import type { AgentTargetKind, TargetOptions } from "../../lib/agent-targets";
 import { track } from "../../lib/analytics";
 import { isJsonOutput, output } from "../../lib/output";
 import { installSkill } from "../../lib/skills-install";
 import { colors } from "../../lib/ui";
+
+const VALID_TARGETS: readonly AgentTargetKind[] = [
+  "claude",
+  "cursor",
+  "agents-md",
+];
+
+function parseTargetsFlag(
+  raw: string | undefined,
+): AgentTargetKind[] | undefined {
+  if (!raw) return undefined;
+  const parts = raw
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean) as AgentTargetKind[];
+  for (const p of parts) {
+    if (!VALID_TARGETS.includes(p)) {
+      throw new Error(
+        `Unknown target '${p}'. Valid targets: ${VALID_TARGETS.join(", ")}`,
+      );
+    }
+  }
+  return parts;
+}
+
+function buildTargetOptions(args: Record<string, unknown>): TargetOptions {
+  const exclude: AgentTargetKind[] = [];
+  if (args.claude === false) exclude.push("claude");
+  if (args.cursor === false) exclude.push("cursor");
+  if (args["agents-md"] === false) exclude.push("agents-md");
+  const only = parseTargetsFlag(args.targets as string | undefined);
+  return { only, exclude: exclude.length ? exclude : undefined };
+}
 
 export default defineCommand({
   meta: {
@@ -19,16 +53,42 @@ export default defineCommand({
       type: "boolean",
       description: "Reinstall even if the skill is already present",
     },
+    targets: {
+      type: "string",
+      description:
+        "Comma-separated list of agent targets (claude, cursor, agents-md). Default: all.",
+    },
+    claude: {
+      type: "boolean",
+      default: true,
+      description:
+        "Write to .claude/skills/ (or .agents/skills/). Use --no-claude to skip.",
+    },
+    cursor: {
+      type: "boolean",
+      default: true,
+      description:
+        "Write the Cursor rule (.cursor/rules/<name>.mdc). Use --no-cursor to skip.",
+    },
+    "agents-md": {
+      type: "boolean",
+      default: true,
+      description:
+        "Append a fenced block to AGENTS.md. Use --no-agents-md to skip.",
+    },
   },
   async run({ args }) {
+    const targetOptions = buildTargetOptions(args as Record<string, unknown>);
     const result = await installSkill(process.cwd(), args.name, {
       force: Boolean(args.force),
+      targetOptions,
     });
 
     track("skills_installed", {
       name: args.name,
       status: result.status,
       force: Boolean(args.force),
+      targets: result.targets.map((t) => t.kind),
     });
 
     if (isJsonOutput()) {
@@ -44,8 +104,13 @@ export default defineCommand({
     process.stdout.write(
       `  ${colors.bold(result.name)}  ${colors.dim(`→ ${result.installedDir}`)}\n`,
     );
+    for (const t of result.targets) {
+      for (const p of t.paths) {
+        process.stdout.write(`      ${colors.dim(`→ ${t.kind}: ${p}`)}\n`);
+      }
+    }
     process.stdout.write(
-      `\n${colors.dim(`Commit ${result.installedDir} so teammates get the same skills.`)}\n\n`,
+      `\n${colors.dim(`Commit the written files so teammates get the same skills.`)}\n\n`,
     );
   },
 });

--- a/src/commands/skills/remove.ts
+++ b/src/commands/skills/remove.ts
@@ -17,12 +17,15 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const { removed, installedDir } = uninstallSkill(process.cwd(), args.name);
+    const { removed, installedDir, targets } = await uninstallSkill(
+      process.cwd(),
+      args.name,
+    );
 
     track("skills_removed", { name: args.name, removed });
 
     if (isJsonOutput()) {
-      output({ name: args.name, removed, installedDir });
+      output({ name: args.name, removed, installedDir, targets });
       return;
     }
 

--- a/src/lib/agent-targets/agents-md.test.ts
+++ b/src/lib/agent-targets/agents-md.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mergeAgentsMd,
+  renderAgentsBlock,
+  stripAgentsBlock,
+} from "./agents-md";
+import type { SkillContent } from "./types";
+
+const skill: SkillContent = {
+  name: "genmedia",
+  description: "Use genmedia for fal.ai things.",
+  body: "# genmedia CLI\n\nDo things.",
+  rawFrontmatter: "---\nname: genmedia\n---\n",
+  files: [],
+};
+
+describe("renderAgentsBlock", () => {
+  test("wraps body with BEGIN/END markers and a heading", () => {
+    const out = renderAgentsBlock(skill);
+    expect(out).toContain("<!-- BEGIN genmedia:genmedia -->");
+    expect(out).toContain("<!-- END genmedia:genmedia -->");
+    expect(out).toContain("## genmedia CLI");
+    expect(out).toContain("Do things.");
+  });
+});
+
+describe("mergeAgentsMd", () => {
+  const block = renderAgentsBlock(skill);
+
+  test("creates content when AGENTS.md is missing", () => {
+    const out = mergeAgentsMd(null, block, "genmedia");
+    expect(out.startsWith("<!-- BEGIN genmedia:genmedia -->")).toBe(true);
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  test("appends to non-empty file without our block", () => {
+    const existing = "# Project AGENTS guide\n\nSome existing instructions.\n";
+    const out = mergeAgentsMd(existing, block, "genmedia");
+    expect(out.startsWith(existing.replace(/\n*$/, ""))).toBe(true);
+    expect(out).toContain("<!-- BEGIN genmedia:genmedia -->");
+  });
+
+  test("replaces an existing block in place", () => {
+    const old = renderAgentsBlock({ ...skill, body: "OLD CONTENT" });
+    const surrounded = `## Pre\nKeep me\n\n${old}\n\n## Post\nKeep me too\n`;
+    const updated = renderAgentsBlock({ ...skill, body: "NEW CONTENT" });
+    const out = mergeAgentsMd(surrounded, updated, "genmedia");
+    expect(out).toContain("Keep me");
+    expect(out).toContain("Keep me too");
+    expect(out).toContain("NEW CONTENT");
+    expect(out).not.toContain("OLD CONTENT");
+  });
+
+  test("is idempotent — same input produces same output", () => {
+    const once = mergeAgentsMd(null, block, "genmedia");
+    const twice = mergeAgentsMd(once, block, "genmedia");
+    expect(twice).toBe(once);
+  });
+
+  test("handles distinct skill blocks side by side", () => {
+    const blockA = renderAgentsBlock({ ...skill, name: "alpha" });
+    const blockB = renderAgentsBlock({ ...skill, name: "beta" });
+    const step1 = mergeAgentsMd(null, blockA, "alpha");
+    const step2 = mergeAgentsMd(step1, blockB, "beta");
+    expect(step2).toContain("<!-- BEGIN genmedia:alpha -->");
+    expect(step2).toContain("<!-- BEGIN genmedia:beta -->");
+    const updatedA = renderAgentsBlock({
+      ...skill,
+      name: "alpha",
+      body: "ALPHA UPDATED",
+    });
+    const step3 = mergeAgentsMd(step2, updatedA, "alpha");
+    expect(step3).toContain("ALPHA UPDATED");
+    expect(step3).toContain("<!-- BEGIN genmedia:beta -->");
+  });
+});
+
+describe("stripAgentsBlock", () => {
+  test("removes our block and preserves surrounding content", () => {
+    const block = renderAgentsBlock(skill);
+    const surrounded = `# Header\n\n${block}\n\n## Post\nKeep\n`;
+    const { content, removed } = stripAgentsBlock(surrounded, "genmedia");
+    expect(removed).toBe(true);
+    expect(content).toContain("# Header");
+    expect(content).toContain("Keep");
+    expect(content).not.toContain("BEGIN genmedia:genmedia");
+  });
+
+  test("reports removed: false when our block is absent", () => {
+    const { content, removed } = stripAgentsBlock(
+      "# Just a regular file",
+      "genmedia",
+    );
+    expect(removed).toBe(false);
+    expect(content).toBe("# Just a regular file");
+  });
+});

--- a/src/lib/agent-targets/agents-md.ts
+++ b/src/lib/agent-targets/agents-md.ts
@@ -1,0 +1,109 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { sha256 } from "../skills-registry";
+import type {
+  AgentTarget,
+  SkillContent,
+  TargetOptions,
+  TargetRemoveResult,
+  TargetWriteResult,
+} from "./types";
+
+const AGENTS_MD = "AGENTS.md";
+
+function beginMarker(skillName: string): string {
+  return `<!-- BEGIN genmedia:${skillName} -->`;
+}
+function endMarker(skillName: string): string {
+  return `<!-- END genmedia:${skillName} -->`;
+}
+
+export function renderAgentsBlock(skill: SkillContent): string {
+  const begin = beginMarker(skill.name);
+  const end = endMarker(skill.name);
+  const heading =
+    skill.name === "genmedia" ? "## genmedia CLI" : `## ${skill.name}`;
+  const body = skill.body.trim();
+  return `${begin}\n${heading}\n\n${body}\n${end}`;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function mergeAgentsMd(
+  existing: string | null,
+  block: string,
+  skillName: string,
+): string {
+  const begin = escapeRegex(beginMarker(skillName));
+  const end = escapeRegex(endMarker(skillName));
+  const blockRe = new RegExp(`${begin}[\\s\\S]*?${end}`);
+
+  if (existing === null || existing === "") {
+    return `${block}\n`;
+  }
+  if (blockRe.test(existing)) {
+    return existing.replace(blockRe, block);
+  }
+  const sep = existing.endsWith("\n\n")
+    ? ""
+    : existing.endsWith("\n")
+      ? "\n"
+      : "\n\n";
+  return `${existing}${sep}${block}\n`;
+}
+
+export function stripAgentsBlock(
+  existing: string,
+  skillName: string,
+): { content: string; removed: boolean } {
+  const begin = escapeRegex(beginMarker(skillName));
+  const end = escapeRegex(endMarker(skillName));
+  const blockRe = new RegExp(`\\n*${begin}[\\s\\S]*?${end}\\n*`);
+  if (!blockRe.test(existing)) return { content: existing, removed: false };
+  const next = existing.replace(blockRe, "\n");
+  return {
+    content: next.replace(/\n{3,}/g, "\n\n").replace(/^\n+/, ""),
+    removed: true,
+  };
+}
+
+export const agentsMdTarget: AgentTarget = {
+  kind: "agents-md",
+
+  enabled(_cwd, opts: TargetOptions) {
+    if (opts.only && !opts.only.includes("agents-md")) return false;
+    if (opts.exclude?.includes("agents-md")) return false;
+    return true;
+  },
+
+  async write(cwd, skill: SkillContent): Promise<TargetWriteResult> {
+    const abs = join(cwd, AGENTS_MD);
+    const existing = existsSync(abs) ? readFileSync(abs, "utf-8") : null;
+    const block = renderAgentsBlock(skill);
+    const next = mergeAgentsMd(existing, block, skill.name);
+    writeFileSync(abs, next, "utf-8");
+    return {
+      kind: "agents-md",
+      paths: [AGENTS_MD],
+      sha256: { [AGENTS_MD]: sha256(next) },
+    };
+  },
+
+  async remove(cwd, skillName): Promise<TargetRemoveResult> {
+    const abs = join(cwd, AGENTS_MD);
+    if (!existsSync(abs)) return { kind: "agents-md", paths: [] };
+    const existing = readFileSync(abs, "utf-8");
+    const { content, removed } = stripAgentsBlock(existing, skillName);
+    if (!removed) return { kind: "agents-md", paths: [] };
+    if (content.trim() === "") {
+      // No other content — leave the file with our last fingerprint removed but don't delete it,
+      // since the user may not have created it.
+      writeFileSync(abs, "", "utf-8");
+    } else {
+      writeFileSync(abs, content, "utf-8");
+    }
+    return { kind: "agents-md", paths: [AGENTS_MD] };
+  },
+};

--- a/src/lib/agent-targets/claude.ts
+++ b/src/lib/agent-targets/claude.ts
@@ -1,0 +1,53 @@
+import { join } from "node:path";
+import {
+  removeSkillDir,
+  resolveSkillsBase,
+  sha256,
+  writeSkillFiles,
+} from "../skills-registry";
+import type {
+  AgentTarget,
+  SkillContent,
+  TargetOptions,
+  TargetRemoveResult,
+  TargetWriteResult,
+} from "./types";
+
+const CLAUDE_DEFAULT_BASE = ".claude/skills";
+
+function pickBase(cwd: string): string {
+  return resolveSkillsBase(cwd) ?? CLAUDE_DEFAULT_BASE;
+}
+
+export const claudeTarget: AgentTarget = {
+  kind: "claude",
+
+  enabled(_cwd, opts: TargetOptions) {
+    if (opts.only && !opts.only.includes("claude")) return false;
+    if (opts.exclude?.includes("claude")) return false;
+    return true;
+  },
+
+  async write(cwd, skill: SkillContent): Promise<TargetWriteResult> {
+    const base = pickBase(cwd);
+    writeSkillFiles(cwd, base, skill.name, skill.files);
+
+    const paths: string[] = [];
+    const hashes: Record<string, string> = {};
+    for (const f of skill.files) {
+      const rel = join(base, skill.name, f.path);
+      paths.push(rel);
+      hashes[rel] = sha256(f.content);
+    }
+    return { kind: "claude", paths, sha256: hashes };
+  },
+
+  async remove(cwd, skillName): Promise<TargetRemoveResult> {
+    const base = pickBase(cwd);
+    const removed = removeSkillDir(cwd, base, skillName);
+    return {
+      kind: "claude",
+      paths: removed ? [join(base, skillName)] : [],
+    };
+  },
+};

--- a/src/lib/agent-targets/cursor.test.ts
+++ b/src/lib/agent-targets/cursor.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { renderCursorRule } from "./cursor";
+import type { SkillContent } from "./types";
+
+const skill: SkillContent = {
+  name: "genmedia",
+  description: "Use the genmedia CLI to run fal.ai models.",
+  body: "# genmedia CLI\n\nDo things.",
+  rawFrontmatter: "---\nname: genmedia\n---\n",
+  files: [],
+};
+
+describe("renderCursorRule", () => {
+  test("emits Cursor frontmatter with description, empty globs, alwaysApply: false", () => {
+    const out = renderCursorRule(skill);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("---");
+    expect(lines[1]).toBe(
+      'description: "Use the genmedia CLI to run fal.ai models."',
+    );
+    expect(lines[2]).toBe("globs:");
+    expect(lines[3]).toBe("alwaysApply: false");
+    expect(lines[4]).toBe("---");
+    expect(out).toContain("# genmedia CLI");
+  });
+
+  test("collapses multi-line description to a single line", () => {
+    const multi: SkillContent = {
+      ...skill,
+      description: "Line one\n  Line two\n  Line three",
+    };
+    const out = renderCursorRule(multi);
+    expect(out).toContain('description: "Line one Line two Line three"');
+  });
+
+  test("escapes double quotes in description", () => {
+    const tricky: SkillContent = {
+      ...skill,
+      description: 'has "quotes" inside',
+    };
+    const out = renderCursorRule(tricky);
+    expect(out).toContain('description: "has \\"quotes\\" inside"');
+  });
+});

--- a/src/lib/agent-targets/cursor.ts
+++ b/src/lib/agent-targets/cursor.ts
@@ -1,0 +1,66 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { sha256 } from "../skills-registry";
+import type {
+  AgentTarget,
+  SkillContent,
+  TargetOptions,
+  TargetRemoveResult,
+  TargetWriteResult,
+} from "./types";
+
+const CURSOR_RULES_DIR = ".cursor/rules";
+
+function rulePath(skillName: string): string {
+  return join(CURSOR_RULES_DIR, `${skillName}.mdc`);
+}
+
+function escapeYamlDouble(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function renderCursorRule(skill: SkillContent): string {
+  const description = skill.description.replace(/\s+/g, " ").trim();
+  const lines = [
+    "---",
+    `description: "${escapeYamlDouble(description)}"`,
+    "globs:",
+    "alwaysApply: false",
+    "---",
+    "",
+    skill.body.trimEnd(),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export const cursorTarget: AgentTarget = {
+  kind: "cursor",
+
+  enabled(_cwd, opts: TargetOptions) {
+    if (opts.only && !opts.only.includes("cursor")) return false;
+    if (opts.exclude?.includes("cursor")) return false;
+    return true;
+  },
+
+  async write(cwd, skill: SkillContent): Promise<TargetWriteResult> {
+    const rel = rulePath(skill.name);
+    const abs = join(cwd, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    const content = renderCursorRule(skill);
+    writeFileSync(abs, content, "utf-8");
+    return {
+      kind: "cursor",
+      paths: [rel],
+      sha256: { [rel]: sha256(content) },
+    };
+  },
+
+  async remove(cwd, skillName): Promise<TargetRemoveResult> {
+    const rel = rulePath(skillName);
+    const abs = join(cwd, rel);
+    if (!existsSync(abs)) return { kind: "cursor", paths: [] };
+    rmSync(abs);
+    return { kind: "cursor", paths: [rel] };
+  },
+};

--- a/src/lib/agent-targets/frontmatter.test.ts
+++ b/src/lib/agent-targets/frontmatter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { parseFrontmatter } from "./frontmatter";
+
+describe("parseFrontmatter", () => {
+  test("returns empty fields when no frontmatter present", () => {
+    const { fields, body, raw } = parseFrontmatter("# Just a body");
+    expect(fields).toEqual({});
+    expect(body).toBe("# Just a body");
+    expect(raw).toBe("");
+  });
+
+  test("parses simple key: value pairs", () => {
+    const text = "---\nname: genmedia\nversion: 1\n---\n\nbody here";
+    const { fields, body } = parseFrontmatter(text);
+    expect(fields.name).toBe("genmedia");
+    expect(fields.version).toBe("1");
+    expect(body).toBe("\nbody here");
+  });
+
+  test("folds `>` block scalars to a single line", () => {
+    const text = [
+      "---",
+      "description: >",
+      "  Use the genmedia CLI to search,",
+      "  run, and manage models.",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    const { fields } = parseFrontmatter(text);
+    expect(fields.description).toBe(
+      "Use the genmedia CLI to search, run, and manage models.",
+    );
+  });
+
+  test("preserves `|` literal scalars line-by-line", () => {
+    const text = [
+      "---",
+      "notes: |",
+      "  line 1",
+      "  line 2",
+      "---",
+      "",
+      "body",
+    ].join("\n");
+    const { fields } = parseFrontmatter(text);
+    expect(fields.notes).toBe("line 1\nline 2");
+  });
+
+  test("strips quotes from quoted values", () => {
+    const text = '---\nname: "quoted"\n---\n';
+    const { fields } = parseFrontmatter(text);
+    expect(fields.name).toBe("quoted");
+  });
+});

--- a/src/lib/agent-targets/frontmatter.ts
+++ b/src/lib/agent-targets/frontmatter.ts
@@ -1,0 +1,78 @@
+export interface ParsedFrontmatter {
+  fields: Record<string, string>;
+  body: string;
+  raw: string;
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+export function parseFrontmatter(text: string): ParsedFrontmatter {
+  const m = FRONTMATTER_RE.exec(text);
+  if (!m) {
+    return { fields: {}, body: text, raw: "" };
+  }
+  return {
+    fields: parseSimpleYaml(m[1]),
+    body: text.slice(m[0].length),
+    raw: m[0],
+  };
+}
+
+function parseSimpleYaml(text: string): Record<string, string> {
+  const fields: Record<string, string> = {};
+  const lines = text.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim() || line.trim().startsWith("#")) {
+      i++;
+      continue;
+    }
+    const m = /^([A-Za-z_][\w-]*)\s*:\s*(.*)$/.exec(line);
+    if (!m) {
+      i++;
+      continue;
+    }
+    const key = m[1];
+    const rest = m[2];
+
+    if (rest === ">" || rest === ">-" || rest === "|" || rest === "|-") {
+      const block: string[] = [];
+      i++;
+      let blockIndent: string | null = null;
+      while (i < lines.length) {
+        const next = lines[i];
+        if (!next.trim()) {
+          block.push("");
+          i++;
+          continue;
+        }
+        const indentMatch = /^(\s+)/.exec(next);
+        if (!indentMatch) break;
+        if (blockIndent === null) blockIndent = indentMatch[1];
+        if (!next.startsWith(blockIndent)) break;
+        block.push(next.slice(blockIndent.length));
+        i++;
+      }
+      const folded = rest.startsWith(">");
+      fields[key] = folded
+        ? block.join(" ").replace(/\s+/g, " ").trim()
+        : block.join("\n").trim();
+    } else {
+      fields[key] = stripQuotes(rest.trim());
+      i++;
+    }
+  }
+  return fields;
+}
+
+function stripQuotes(s: string): string {
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}

--- a/src/lib/agent-targets/index.ts
+++ b/src/lib/agent-targets/index.ts
@@ -1,0 +1,54 @@
+import { agentsMdTarget } from "./agents-md";
+import { claudeTarget } from "./claude";
+import { cursorTarget } from "./cursor";
+import { parseFrontmatter } from "./frontmatter";
+import type {
+  AgentTarget,
+  AgentTargetKind,
+  SkillContent,
+  TargetOptions,
+} from "./types";
+
+export const ALL_TARGETS: AgentTarget[] = [
+  claudeTarget,
+  cursorTarget,
+  agentsMdTarget,
+];
+
+export function resolveTargets(
+  cwd: string,
+  opts: TargetOptions = {},
+): AgentTarget[] {
+  return ALL_TARGETS.filter((t) => t.enabled(cwd, opts));
+}
+
+const SKILL_MD_PATH = "SKILL.md";
+
+export function buildSkillContent(
+  name: string,
+  description: string,
+  files: Array<{ path: string; content: string }>,
+): SkillContent {
+  const skillMd = files.find((f) => f.path === SKILL_MD_PATH);
+  if (!skillMd) {
+    return {
+      name,
+      description,
+      body: "",
+      rawFrontmatter: "",
+      files,
+    };
+  }
+  const parsed = parseFrontmatter(skillMd.content);
+  const resolvedDescription =
+    parsed.fields.description?.trim() || description.trim();
+  return {
+    name,
+    description: resolvedDescription,
+    body: parsed.body,
+    rawFrontmatter: parsed.raw,
+    files,
+  };
+}
+
+export type { AgentTarget, AgentTargetKind, SkillContent, TargetOptions };

--- a/src/lib/agent-targets/types.ts
+++ b/src/lib/agent-targets/types.ts
@@ -1,0 +1,32 @@
+export type AgentTargetKind = "claude" | "cursor" | "agents-md";
+
+export interface SkillContent {
+  name: string;
+  description: string;
+  body: string;
+  rawFrontmatter: string;
+  files: Array<{ path: string; content: string }>;
+}
+
+export interface TargetWriteResult {
+  kind: AgentTargetKind;
+  paths: string[];
+  sha256: Record<string, string>;
+}
+
+export interface TargetRemoveResult {
+  kind: AgentTargetKind;
+  paths: string[];
+}
+
+export interface TargetOptions {
+  only?: AgentTargetKind[];
+  exclude?: AgentTargetKind[];
+}
+
+export interface AgentTarget {
+  kind: AgentTargetKind;
+  enabled(cwd: string, opts: TargetOptions): boolean;
+  write(cwd: string, skill: SkillContent): Promise<TargetWriteResult>;
+  remove(cwd: string, skillName: string): Promise<TargetRemoveResult>;
+}

--- a/src/lib/skills-install.ts
+++ b/src/lib/skills-install.ts
@@ -1,11 +1,20 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type AgentTargetKind,
+  ALL_TARGETS,
+  buildSkillContent,
+  resolveTargets,
+  type TargetOptions,
+} from "./agent-targets";
 import { error } from "./output";
 import {
-  AGENT_ROOTS,
   fetchIndex,
   fetchSkillFile,
   findSkill,
   getRegistryUrl,
   type InstalledSkill,
+  type InstalledTarget,
   readInstalledManifest,
   removeInstalled,
   removeSkillDir,
@@ -14,15 +23,22 @@ import {
   sha256,
   upsertInstalled,
   writeInstalledManifest,
-  writeSkillFiles,
 } from "./skills-registry";
 import { colors, createSpinner, symbols } from "./ui";
+
+const DEFAULT_MANIFEST_BASE = ".claude/skills";
 
 export interface InstallOptions {
   force?: boolean;
   silent?: boolean;
   sharedIndex?: SkillsIndex;
   spinner?: ReturnType<typeof createSpinner>;
+  targetOptions?: TargetOptions;
+}
+
+export interface InstallTargetResult {
+  kind: AgentTargetKind;
+  paths: string[];
 }
 
 export interface InstallResult {
@@ -30,6 +46,7 @@ export interface InstallResult {
   status: "installed" | "updated" | "skipped";
   installedDir: string;
   files: string[];
+  targets: InstallTargetResult[];
 }
 
 export async function getIndex(): Promise<SkillsIndex> {
@@ -43,15 +60,11 @@ export async function getIndex(): Promise<SkillsIndex> {
   }
 }
 
-function requireSkillsBase(cwd: string): string {
-  const base = resolveSkillsBase(cwd);
-  if (!base) {
-    error(
-      `No agent directory found. Create '${AGENT_ROOTS[0]}/' or '${AGENT_ROOTS[1]}/' in this project and try again.`,
-      { checked: AGENT_ROOTS.map((r) => `${r}/`) },
-    );
-  }
-  return base;
+function manifestBase(cwd: string): string {
+  const resolved = resolveSkillsBase(cwd);
+  if (resolved) return resolved;
+  mkdirSync(join(cwd, DEFAULT_MANIFEST_BASE), { recursive: true });
+  return DEFAULT_MANIFEST_BASE;
 }
 
 export async function installSkill(
@@ -59,8 +72,6 @@ export async function installSkill(
   name: string,
   options: InstallOptions = {},
 ): Promise<InstallResult> {
-  const base = requireSkillsBase(cwd);
-
   const spinner = options.spinner ?? createSpinner();
   const ownSpinner = !options.spinner;
   if (ownSpinner && !options.silent) spinner.start(`Fetching registry…`);
@@ -77,19 +88,20 @@ export async function installSkill(
   let manifest = readInstalledManifest(cwd);
   const already = manifest.skills.some((s) => s.name === name);
   if (already && !options.force) {
-    if (ownSpinner) {
-      spinner.stop();
-    }
+    if (ownSpinner) spinner.stop();
     if (!options.silent) {
       spinner.log(
         `${colors.yellow(symbols.warning)} ${name} already installed (use --force to reinstall)`,
       );
     }
+    const previous = manifest.skills.find((s) => s.name === name);
     return {
       name,
       status: "skipped",
-      installedDir: `${base}/${name}`,
+      installedDir: `${manifestBase(cwd)}/${name}`,
       files: entry.files.map((f) => f.path),
+      targets:
+        previous?.targets?.map((t) => ({ kind: t.kind, paths: t.paths })) ?? [],
     };
   }
 
@@ -109,15 +121,32 @@ export async function installSkill(
     files.push({ path: f.path, content });
   }
 
-  writeSkillFiles(cwd, base, name, files);
+  const skill = buildSkillContent(name, entry.description, files);
+
+  const enabledTargets = resolveTargets(cwd, options.targetOptions ?? {});
+  const targetWrites: InstalledTarget[] = [];
+  for (const target of enabledTargets) {
+    const result = await target.write(cwd, skill);
+    targetWrites.push({
+      kind: result.kind,
+      paths: result.paths,
+      sha256: result.sha256,
+    });
+  }
+
+  const base = manifestBase(cwd);
+  const claudeWrite = targetWrites.find((t) => t.kind === "claude");
 
   const record: InstalledSkill = {
     name: entry.name,
     description: entry.description,
-    files: entry.files.map((f) => f.path),
-    sha256: Object.fromEntries(entry.files.map((f) => [f.path, f.sha256])),
+    files: claudeWrite?.paths ?? entry.files.map((f) => f.path),
+    sha256:
+      claudeWrite?.sha256 ??
+      Object.fromEntries(entry.files.map((f) => [f.path, f.sha256])),
     installedAt: new Date().toISOString(),
     source: `${getRegistryUrl()}/${name}`,
+    targets: targetWrites,
   };
   manifest = upsertInstalled(manifest, record);
   writeInstalledManifest(cwd, base, manifest);
@@ -127,8 +156,9 @@ export async function installSkill(
       `${already ? "Updated" : "Installed"} ${colors.bold(name)}`,
     );
   } else if (!options.silent) {
+    const targetSummary = targetWrites.map((t) => t.kind).join(", ");
     spinner.log(
-      `  ${colors.green(symbols.success)} ${colors.bold(name)}  ${colors.dim(`${files.length} file${files.length === 1 ? "" : "s"}`)}`,
+      `  ${colors.green(symbols.success)} ${colors.bold(name)}  ${colors.dim(targetSummary)}`,
     );
   }
 
@@ -137,27 +167,52 @@ export async function installSkill(
     status: already ? "updated" : "installed",
     installedDir: `${base}/${name}`,
     files: entry.files.map((f) => f.path),
+    targets: targetWrites.map((t) => ({ kind: t.kind, paths: t.paths })),
   };
 }
 
-export function uninstallSkill(
+export interface UninstallResult {
+  removed: boolean;
+  installedDir: string | null;
+  targets: InstallTargetResult[];
+}
+
+export async function uninstallSkill(
   cwd: string,
   name: string,
-): { removed: boolean; installedDir: string | null } {
+): Promise<UninstallResult> {
   const base = resolveSkillsBase(cwd);
-  if (!base) {
-    return { removed: false, installedDir: null };
-  }
-
   let manifest = readInstalledManifest(cwd);
   const entry = manifest.skills.find((s) => s.name === name);
 
-  const fileRemoved = removeSkillDir(cwd, base, name);
+  const removed: InstallTargetResult[] = [];
+
+  if (entry?.targets && entry.targets.length > 0) {
+    for (const t of entry.targets) {
+      const target = ALL_TARGETS.find((x) => x.kind === t.kind);
+      if (!target) continue;
+      const result = await target.remove(cwd, name);
+      if (result.paths.length > 0) {
+        removed.push({ kind: result.kind, paths: result.paths });
+      }
+    }
+  } else if (base) {
+    const fileRemoved = removeSkillDir(cwd, base, name);
+    if (fileRemoved) {
+      removed.push({ kind: "claude", paths: [`${base}/${name}`] });
+    }
+  }
+
   manifest = removeInstalled(manifest, name);
-  writeInstalledManifest(cwd, base, manifest);
+  if (base) {
+    writeInstalledManifest(cwd, base, manifest);
+  } else if (existsSync(join(cwd, DEFAULT_MANIFEST_BASE))) {
+    writeInstalledManifest(cwd, DEFAULT_MANIFEST_BASE, manifest);
+  }
 
   return {
-    removed: Boolean(entry) || fileRemoved,
-    installedDir: `${base}/${name}`,
+    removed: Boolean(entry) || removed.length > 0,
+    installedDir: base ? `${base}/${name}` : null,
+    targets: removed,
   };
 }

--- a/src/lib/skills-registry.ts
+++ b/src/lib/skills-registry.ts
@@ -45,6 +45,14 @@ export interface SkillSearchResponse {
   skills: SkillSearchHit[];
 }
 
+export type InstalledTargetKind = "claude" | "cursor" | "agents-md";
+
+export interface InstalledTarget {
+  kind: InstalledTargetKind;
+  paths: string[];
+  sha256: Record<string, string>;
+}
+
 export interface InstalledSkill {
   name: string;
   description: string;
@@ -52,6 +60,7 @@ export interface InstalledSkill {
   sha256: Record<string, string>;
   installedAt: string;
   source: string;
+  targets?: InstalledTarget[];
 }
 
 export interface InstalledManifest {


### PR DESCRIPTION
## Summary

- `genmedia init` now writes a single canonical skill to **every** agent surface in the repo (Claude, Cursor, AGENTS.md) instead of picking one — turning the long-promised distribution wedge into something that actually fires.
- Introduces an `AgentTarget` abstraction so each surface owns its own write/remove logic; adding new targets (e.g. `.codex/skills/`) is now ~30 lines, not a refactor.
- Extends the installed-skills manifest with a `targets[]` array so `update` and `remove` reverse multi-target installs cleanly. Legacy single-base entries still work — `uninstallSkill` falls back when `targets[]` is absent.

## Behavior

| Target | Output | Format |
|---|---|---|
| **claude** | `.claude/skills/<name>/SKILL.md` (+ `references/`), or `.agents/skills/<name>/` if `.agents/` exists | Pass-through. **Byte-identical to upstream registry — co-exists with `npx skills add`** so users can switch between or run both tools without conflict. |
| **cursor** | `.cursor/rules/<name>.mdc` | Cursor-compatible frontmatter (`description`, empty `globs`, `alwaysApply: false`). Description is escaped/folded from SKILL.md. Cursor's native rules engine picks it up. |
| **agents-md** | `AGENTS.md` at repo root | Idempotent fenced-block merge (`<!-- BEGIN/END genmedia:<name> -->`). Creates the file if missing, appends if absent, replaces in place if the marker exists. Per-skill markers so multiple skills coexist. |

All three are active by default. Per-target opt-out via `--no-claude` / `--no-cursor` / `--no-agents-md`. Explicit allowlist via `--targets claude,cursor`. Same flag set is added to `skills install`.

The `skills_installed` analytics event now carries `targets: ["claude","cursor","agents-md"]` so we can track which surfaces are actually being written across installs.

## Files

**New** (`src/lib/agent-targets/`):
- `types.ts` — `AgentTarget`, `SkillContent`, result types
- `frontmatter.ts` — minimal YAML splitter for SKILL.md frontmatter (no new dep; folded `>` and literal `|` scalars supported)
- `claude.ts` — wraps existing `writeSkillFiles` / `removeSkillDir`
- `cursor.ts` — `.mdc` transform + write/remove
- `agents-md.ts` — idempotent fenced-block merge (`mergeAgentsMd`, `stripAgentsBlock`)
- `index.ts` — `ALL_TARGETS`, `resolveTargets()`, `buildSkillContent()`
- `*.test.ts` — 16 unit tests covering frontmatter parsing, AGENTS.md merge idempotency, Cursor `.mdc` rendering, multi-skill coexistence

**Modified:**
- `src/lib/skills-registry.ts` — adds `InstalledTarget` and optional `targets[]` on `InstalledSkill` (legacy fields preserved)
- `src/lib/skills-install.ts` — `installSkill` loops enabled targets; `uninstallSkill` is async and walks `targets[]`
- `src/commands/init.ts`, `src/commands/skills/install.ts` — new flags + per-target output rendering
- `src/commands/skills/remove.ts` — awaits async `uninstallSkill`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` (biome) — clean
- [x] `bun run build` — single binary compiles
- [x] `bun test src/lib/agent-targets/` — 16 tests pass
- [x] End-to-end against the compiled binary in tmp fixtures:
  - [x] `genmedia init` writes all three artifacts; JSON output reports per-target paths
  - [x] Re-run is idempotent — AGENTS.md size and `BEGIN` marker count unchanged
  - [x] `genmedia skills remove genmedia` cleans all three artifacts; preserves unrelated AGENTS.md content
  - [x] `--no-cursor` / `--no-agents-md` / `--targets claude` correctly scope writes
- [x] **Co-existence with `npx skills add fal-ai-community/skills`** — both tools run against the same fixture; SKILL.md is byte-identical, no conflict, Cursor + AGENTS.md remain ours
- [x] Manual smoke in real Claude Code session ✅ (verified)
- [x] Manual smoke in real Cursor IDE
- [x] Manual smoke with a Codex / Cline / Aider session reading AGENTS.md

## Out of scope (follow-ups)

- Submitting `genmedia` to the Vercel `skills` index — orthogonal free distribution win.
- `.codex/skills/` target — the format isn't stable yet; AGENTS.md covers Codex for now.