### PR TITLE
feat: smart-default routing + filtered discovery for `run` and `models`

### DIFF
--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -1,5 +1,7 @@
 import { defineCommand } from "citty";
+import { track } from "../lib/analytics";
 import { PLATFORM_BASE, platformHeaders } from "../lib/api";
+import { classifyModality, modalityToCategory } from "../lib/modality";
 import { error, output } from "../lib/output";
 
 const SUPPORTED_EXPANDS = new Set(["openapi-3.0", "enterprise_status"]);
@@ -147,6 +149,12 @@ export default defineCommand({
       description:
         "Expand fields. Repeat the flag or pass comma-separated values: openapi-3.0, enterprise_status",
     },
+    classify: {
+      type: "boolean",
+      default: true,
+      description:
+        "When --category is not set, infer it from the query. Use --no-classify to disable.",
+    },
   },
   async run({ args, rawArgs }) {
     const query = args.query?.trim();
@@ -162,9 +170,24 @@ export default defineCommand({
       }
     }
 
+    // Auto-classify: when no --category was passed and we have a query,
+    // infer the category from the query so agents get a focused result set
+    // instead of every modality. `--no-classify` disables.
+    let inferredCategory: string | undefined;
+    let resolvedCategory = args.category;
+    if (!resolvedCategory && query && args.classify !== false) {
+      const modality = classifyModality(query);
+      inferredCategory = modalityToCategory(modality);
+      resolvedCategory = inferredCategory;
+      track("models_classified", {
+        query,
+        inferred_category: inferredCategory,
+      });
+    }
+
     const url = new URL(`${PLATFORM_BASE}/models`);
     if (query) url.searchParams.set("q", query);
-    if (args.category) url.searchParams.set("category", args.category);
+    if (resolvedCategory) url.searchParams.set("category", resolvedCategory);
     if (args.status !== "all") url.searchParams.set("status", args.status);
     url.searchParams.set("limit", parseLimit(args.limit));
     if (args.cursor) url.searchParams.set("cursor", args.cursor);
@@ -183,7 +206,8 @@ export default defineCommand({
 
     output({
       ...(query ? { query } : {}),
-      ...(args.category ? { category: args.category } : {}),
+      ...(resolvedCategory ? { category: resolvedCategory } : {}),
+      ...(inferredCategory ? { inferred_category: inferredCategory } : {}),
       ...(args.status !== "all" ? { status: args.status } : {}),
       ...(endpointIds.length > 0 ? { endpoint_ids: endpointIds } : {}),
       ...(expand.length > 0 ? { expand } : {}),

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -140,6 +140,18 @@ export default defineCommand({
       }
     }
 
+    // Flat discriminator for analytics dashboards; the nested `routed` field
+    // carries the modality + manifest source for routed calls.
+    const trackingMode: {
+      caller_mode: "routed" | "explicit";
+      routed?: { modality: Modality; source: ResolvedDefault["source"] };
+    } = routed
+      ? {
+          caller_mode: "routed",
+          routed: { modality: routed.modality, source: routed.source },
+        }
+      : { caller_mode: "explicit" };
+
     const modelStart = performance.now();
 
     if (args.async) {
@@ -150,9 +162,7 @@ export default defineCommand({
           mode: "async",
           ok: true,
           durationMs: Math.round(performance.now() - modelStart),
-          ...(routed
-            ? { routed: { modality: routed.modality, source: routed.source } }
-            : {}),
+          ...trackingMode,
         });
         output(
           {
@@ -171,9 +181,7 @@ export default defineCommand({
           ok: false,
           durationMs: Math.round(performance.now() - modelStart),
           errorClass: (submitErr as Error)?.constructor?.name ?? "Error",
-          ...(routed
-            ? { routed: { modality: routed.modality, source: routed.source } }
-            : {}),
+          ...trackingMode,
         });
         throw submitErr;
       }
@@ -225,9 +233,7 @@ export default defineCommand({
         mode: "subscribe",
         ok: true,
         durationMs: Math.round(performance.now() - modelStart),
-        ...(routed
-          ? { routed: { modality: routed.modality, source: routed.source } }
-          : {}),
+        ...trackingMode,
       });
       spinner?.succeed(`Run completed (${result.requestId})`);
 
@@ -286,9 +292,7 @@ export default defineCommand({
         durationMs: Math.round(performance.now() - modelStart),
         errorClass:
           formatted.name ?? (runError as Error)?.constructor?.name ?? "Error",
-        ...(routed
-          ? { routed: { modality: routed.modality, source: routed.source } }
-          : {}),
+        ...trackingMode,
       });
       spinner?.fail(requestId ? `Run failed (${requestId})` : "Run failed");
       error(

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,11 +3,16 @@ import { defineCommand } from "citty";
 import { track } from "../lib/analytics";
 import { configureSDK } from "../lib/api";
 import {
+  type ResolvedDefault,
+  resolveDefaultEndpoint,
+} from "../lib/defaults-manifest";
+import {
   downloadMedia,
   extractMediaRefs,
   parseDownloadFlag,
 } from "../lib/download";
 import { formatApiError } from "../lib/error-format";
+import { classifyModality, type Modality } from "../lib/modality";
 import { error, isPrettyOutput, output } from "../lib/output";
 import { parseValue } from "../lib/parse-value";
 import {
@@ -22,13 +27,23 @@ function formatLiveLog(log: CliLogEntry): string {
   return `  ${colors.bold(log.level.padEnd(7))} ${log.message}${timestamp}`;
 }
 
+interface RoutedInfo {
+  modality: Modality;
+  source: ResolvedDefault["source"];
+  from_prompt: string;
+}
+
 export default defineCommand({
-  meta: { name: "run", description: "Run any model (waits for result)" },
+  meta: {
+    name: "run",
+    description:
+      'Run a model. Pass an endpoint ID, or a prompt for smart routing (e.g. `genmedia run "a cat on the moon"`).',
+  },
   args: {
     endpointId: {
       type: "positional",
-      required: true,
-      description: "Model endpoint ID",
+      required: false,
+      description: "Model endpoint ID, or a prompt for smart routing",
     },
     async: {
       type: "boolean",
@@ -46,8 +61,6 @@ export default defineCommand({
   },
   async run({ args }) {
     configureSDK();
-
-    const { endpointId } = args;
 
     const argv = process.argv.slice(2);
     const download = parseDownloadFlag(argv);
@@ -77,6 +90,56 @@ export default defineCommand({
       }
     }
 
+    // Decide whether the positional is an endpoint ID (contains "/") or a
+    // prompt (smart routing kicks in). Endpoint IDs always look like
+    // "fal-ai/<family>/<variant>"; prompts almost never contain a slash.
+    const positional = args.endpointId;
+    let endpointId: string | undefined;
+    let routed: RoutedInfo | undefined;
+
+    if (positional?.includes("/")) {
+      endpointId = positional;
+    } else {
+      const promptFromPositional =
+        positional && !positional.includes("/") ? positional : undefined;
+      const promptFromInput =
+        typeof input.prompt === "string" ? (input.prompt as string) : undefined;
+      const prompt = promptFromPositional ?? promptFromInput;
+
+      if (!prompt) {
+        error(
+          "Run requires either an endpoint ID, a prompt positional, or --prompt",
+          {
+            usage: 'genmedia run [<endpoint_id> | "<prompt>"] [--key value …]',
+            examples: [
+              "genmedia run fal-ai/flux/dev --prompt 'a cat'",
+              "genmedia run 'a cat on the moon'",
+              "genmedia run --prompt 'a cat'",
+            ],
+          },
+        );
+      }
+
+      const modality = classifyModality(prompt);
+      const resolved = await resolveDefaultEndpoint(modality);
+      endpointId = resolved.endpoint_id;
+      routed = {
+        modality,
+        source: resolved.source,
+        from_prompt: prompt,
+      };
+      // Inject prompt into input only if it wasn't already passed via --prompt
+      if (input.prompt === undefined) {
+        input.prompt = prompt;
+      }
+
+      if (isPrettyOutput()) {
+        process.stderr.write(
+          `${colors.dim(`Routing → ${modality} → ${endpointId}`)}\n`,
+        );
+      }
+    }
+
     const modelStart = performance.now();
 
     if (args.async) {
@@ -87,12 +150,16 @@ export default defineCommand({
           mode: "async",
           ok: true,
           durationMs: Math.round(performance.now() - modelStart),
+          ...(routed
+            ? { routed: { modality: routed.modality, source: routed.source } }
+            : {}),
         });
         output(
           {
             status: "submitted",
             request_id: result.request_id,
             endpoint_id: endpointId,
+            ...(routed ? { routed } : {}),
             hint: `Check status: genmedia status ${endpointId} ${result.request_id}`,
           },
           { view: "run" },
@@ -104,6 +171,9 @@ export default defineCommand({
           ok: false,
           durationMs: Math.round(performance.now() - modelStart),
           errorClass: (submitErr as Error)?.constructor?.name ?? "Error",
+          ...(routed
+            ? { routed: { modality: routed.modality, source: routed.source } }
+            : {}),
         });
         throw submitErr;
       }
@@ -155,6 +225,9 @@ export default defineCommand({
         mode: "subscribe",
         ok: true,
         durationMs: Math.round(performance.now() - modelStart),
+        ...(routed
+          ? { routed: { modality: routed.modality, source: routed.source } }
+          : {}),
       });
       spinner?.succeed(`Run completed (${result.requestId})`);
 
@@ -195,6 +268,7 @@ export default defineCommand({
           endpoint_id: endpointId,
           request_id: result.requestId,
           result: result.data,
+          ...(routed ? { routed } : {}),
           ...(downloaded ? { downloaded_files: downloaded.downloaded } : {}),
           ...(downloaded && downloaded.failed.length > 0
             ? { download_failures: downloaded.failed }
@@ -212,6 +286,9 @@ export default defineCommand({
         durationMs: Math.round(performance.now() - modelStart),
         errorClass:
           formatted.name ?? (runError as Error)?.constructor?.name ?? "Error",
+        ...(routed
+          ? { routed: { modality: routed.modality, source: routed.source } }
+          : {}),
       });
       spinner?.fail(requestId ? `Run failed (${requestId})` : "Run failed");
       error(
@@ -226,6 +303,7 @@ export default defineCommand({
           ...(formatted.validation_errors
             ? { validation_errors: formatted.validation_errors }
             : {}),
+          ...(routed ? { routed } : {}),
           ...(logs.length > 0 ? { logs: logs.slice(-10) } : {}),
           ...(formatted.body !== undefined ? { body: formatted.body } : {}),
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ async function startCli(): Promise<void> {
         models: {
           description: "Search, list, and inspect fal.ai models",
           usage:
-            "genmedia models [query] [--category <cat>] [--status <s>] [--limit <n>] [--cursor <token>] [--endpoint_id <id>] [--expand <field>]",
+            "genmedia models [query] [--category <cat>] [--status <s>] [--limit <n>] [--cursor <token>] [--endpoint_id <id>] [--expand <field>] [--no-classify]",
           args: "[query]",
           options: {
             "--category":
@@ -89,6 +89,8 @@ async function startCli(): Promise<void> {
             "--endpoint_id":
               "Specific endpoint ID(s). Repeat the flag or pass comma-separated values",
             "--expand": "Expand fields: openapi-3.0, enterprise_status",
+            "--no-classify":
+              "Skip auto-inference of --category from the query (default: on when --category is not set)",
           },
         },
         schema: {
@@ -100,11 +102,16 @@ async function startCli(): Promise<void> {
           },
         },
         run: {
-          description: "Run any model (waits for result)",
+          description:
+            "Run any model. Pass an endpoint ID, or a prompt for smart routing.",
           usage:
-            "genmedia run <endpoint_id> [--key value ...] [--logs] [--download [template]]",
-          args: "<endpoint_id>",
+            'genmedia run [<endpoint_id> | "<prompt>"] [--key value ...] [--logs] [--download [template]]',
+          args: "[<endpoint_id> | <prompt>]",
           options: {
+            "<endpoint_id>":
+              "Endpoint ID (must contain '/', e.g. 'fal-ai/flux/dev')",
+            "<prompt>":
+              "Smart routing: a prompt without '/' (e.g. 'a cat on the moon') is classified by modality and routed to a sensible default endpoint. Override with an explicit endpoint ID.",
             "--<key>": "Input parameter (e.g. --prompt 'a cat' --num_images 2)",
             "--async":
               "Submit to queue instead of waiting (returns request_id)",
@@ -235,7 +242,14 @@ async function startCli(): Promise<void> {
         const argv = process.argv.slice(2);
         if (argv[0] === "run" && argv.includes("--help")) {
           const endpointId = argv[1];
-          if (endpointId && !endpointId.startsWith("--")) {
+          // Only fetch a model schema for true endpoint IDs (which always
+          // contain "/", e.g. fal-ai/flux/dev). A bare prompt like
+          // `genmedia run "a cat" --help` falls through to static run help.
+          if (
+            endpointId &&
+            !endpointId.startsWith("--") &&
+            endpointId.includes("/")
+          ) {
             const dynamic = await buildDynamicRunCommand(endpointId);
             if (dynamic) return dynamic;
           }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,6 +17,17 @@ import { join } from "node:path";
 
 export type OutputFormat = "auto" | "json" | "standard";
 
+// Forward-declared shape of the routing-defaults manifest cache. The full
+// `DefaultsManifest` type lives in `src/lib/defaults-manifest.ts` to keep the
+// classifier+manifest module self-contained.
+export interface DefaultsManifestCacheEntry {
+  fetchedAt: number;
+  manifest: {
+    version: 1;
+    defaults: Record<string, string>;
+  };
+}
+
 // In-memory representation — apiKey is always decrypted here
 export interface GenmediaConfig {
   apiKey?: string;
@@ -27,6 +38,7 @@ export interface GenmediaConfig {
   latestKnownVersion?: string;
   installationId?: string;
   analyticsOptOut?: boolean;
+  defaultsManifestCache?: DefaultsManifestCacheEntry;
 }
 
 // On-disk representation — apiKey is stored encrypted, never plaintext
@@ -39,6 +51,7 @@ interface StoredConfig {
   latestKnownVersion?: string;
   installationId?: string;
   analyticsOptOut?: boolean;
+  defaultsManifestCache?: DefaultsManifestCacheEntry;
 }
 
 export const CONFIG_DIR = join(userInfo().homedir, ".genmedia");
@@ -98,6 +111,7 @@ export function loadConfig(): GenmediaConfig {
         latestKnownVersion: stored.latestKnownVersion,
         installationId: stored.installationId,
         analyticsOptOut: stored.analyticsOptOut,
+        defaultsManifestCache: stored.defaultsManifestCache,
         ...(stored.apiKey
           ? { apiKey: decryptApiKey(stored.apiKey) ?? undefined }
           : {}),
@@ -123,6 +137,7 @@ export function saveConfig(config: GenmediaConfig): void {
     latestKnownVersion: config.latestKnownVersion,
     installationId: config.installationId,
     analyticsOptOut: config.analyticsOptOut,
+    defaultsManifestCache: config.defaultsManifestCache,
     ...(config.apiKey ? { apiKey: encryptApiKey(config.apiKey) } : {}),
   };
   writeFileSync(CONFIG_FILE, JSON.stringify(stored, null, 2), "utf-8");

--- a/src/lib/defaults-manifest.test.ts
+++ b/src/lib/defaults-manifest.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BAKED_IN,
+  type DefaultsManifest,
+  decideResolution,
+  isValidManifest,
+  TTL_MS,
+} from "./defaults-manifest";
+
+const NOW = 1_700_000_000_000;
+
+const fetchedManifest: DefaultsManifest = {
+  version: 1,
+  defaults: {
+    "text-to-image": "fal-ai/server-side-default-image",
+    "text-to-video": "fal-ai/server-side-default-video",
+    "text-to-audio-music": "fal-ai/server-side-default-music",
+    "text-to-audio-tts": "fal-ai/server-side-default-tts",
+    "text-to-3d": "fal-ai/server-side-default-3d",
+  },
+};
+
+const cachedManifest: DefaultsManifest = {
+  version: 1,
+  defaults: {
+    "text-to-image": "fal-ai/cached-default-image",
+    "text-to-video": "fal-ai/cached-default-video",
+    "text-to-audio-music": "fal-ai/cached-default-music",
+    "text-to-audio-tts": "fal-ai/cached-default-tts",
+    "text-to-3d": "fal-ai/cached-default-3d",
+  },
+};
+
+describe("decideResolution — cache hit path", () => {
+  test("uses fresh cache, no save", () => {
+    const out = decideResolution({
+      modality: "text-to-image",
+      cached: { fetchedAt: NOW - 1000, manifest: cachedManifest },
+      fetched: null,
+      now: NOW,
+    });
+    expect(out.result.endpoint_id).toBe("fal-ai/cached-default-image");
+    expect(out.result.source).toBe("cached");
+    expect(out.saveCache).toBeUndefined();
+  });
+});
+
+describe("decideResolution — manifest fetch path", () => {
+  test("uses fetched manifest when cache is missing, schedules save", () => {
+    const out = decideResolution({
+      modality: "text-to-video",
+      cached: undefined,
+      fetched: fetchedManifest,
+      now: NOW,
+    });
+    expect(out.result.endpoint_id).toBe("fal-ai/server-side-default-video");
+    expect(out.result.source).toBe("manifest");
+    expect(out.saveCache).toEqual({
+      fetchedAt: NOW,
+      manifest: fetchedManifest,
+    });
+  });
+
+  test("fetched manifest overrides stale cache", () => {
+    const out = decideResolution({
+      modality: "text-to-image",
+      cached: { fetchedAt: NOW - TTL_MS - 1, manifest: cachedManifest },
+      fetched: fetchedManifest,
+      now: NOW,
+    });
+    expect(out.result.endpoint_id).toBe("fal-ai/server-side-default-image");
+    expect(out.result.source).toBe("manifest");
+    expect(out.saveCache).toBeDefined();
+  });
+});
+
+describe("decideResolution — stale cache fallback", () => {
+  test("uses stale cache when fetch fails", () => {
+    const out = decideResolution({
+      modality: "text-to-image",
+      cached: { fetchedAt: NOW - TTL_MS - 1, manifest: cachedManifest },
+      fetched: null,
+      now: NOW,
+    });
+    expect(out.result.endpoint_id).toBe("fal-ai/cached-default-image");
+    expect(out.result.source).toBe("cached");
+    expect(out.saveCache).toBeUndefined();
+  });
+});
+
+describe("decideResolution — baked-in fallback", () => {
+  test("uses BAKED_IN when no cache and fetch fails", () => {
+    const out = decideResolution({
+      modality: "text-to-image",
+      cached: undefined,
+      fetched: null,
+      now: NOW,
+    });
+    expect(out.result.endpoint_id).toBe(BAKED_IN.defaults["text-to-image"]);
+    expect(out.result.source).toBe("baked-in");
+    expect(out.saveCache).toBeUndefined();
+  });
+
+  test("uses BAKED_IN when fetched manifest is missing the modality entry", () => {
+    const partial = {
+      version: 1,
+      // intentionally missing "text-to-3d"
+      defaults: {
+        "text-to-image": "x",
+        "text-to-video": "y",
+        "text-to-audio-music": "m",
+        "text-to-audio-tts": "t",
+      },
+    } as DefaultsManifest;
+    const out = decideResolution({
+      modality: "text-to-3d",
+      cached: undefined,
+      fetched: partial,
+      now: NOW,
+    });
+    expect(out.result.endpoint_id).toBe(BAKED_IN.defaults["text-to-3d"]);
+    expect(out.result.source).toBe("baked-in");
+  });
+});
+
+describe("isValidManifest", () => {
+  test("accepts a well-formed v1 manifest", () => {
+    expect(isValidManifest(fetchedManifest)).toBe(true);
+  });
+
+  test("rejects null and primitives", () => {
+    expect(isValidManifest(null)).toBe(false);
+    expect(isValidManifest(undefined)).toBe(false);
+    expect(isValidManifest("manifest")).toBe(false);
+    expect(isValidManifest(42)).toBe(false);
+  });
+
+  test("rejects non-v1 versions", () => {
+    expect(isValidManifest({ version: 2, defaults: {} })).toBe(false);
+  });
+
+  test("rejects manifest without defaults object", () => {
+    expect(isValidManifest({ version: 1 })).toBe(false);
+    expect(isValidManifest({ version: 1, defaults: null })).toBe(false);
+    expect(isValidManifest({ version: 1, defaults: "x" })).toBe(false);
+  });
+});

--- a/src/lib/defaults-manifest.ts
+++ b/src/lib/defaults-manifest.ts
@@ -1,0 +1,145 @@
+import {
+  type DefaultsManifestCacheEntry,
+  loadConfig,
+  saveConfig,
+} from "./config";
+import type { Modality } from "./modality";
+
+const MANIFEST_URL =
+  process.env.GENMEDIA_DEFAULTS_URL ?? "https://genmedia.sh/defaults.json";
+
+const TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const FETCH_TIMEOUT_MS = 1000;
+
+export type DefaultsSource = "manifest" | "cached" | "baked-in";
+
+export interface DefaultsManifest {
+  version: 1;
+  defaults: Record<Modality, string>;
+}
+
+export interface ResolvedDefault {
+  endpoint_id: string;
+  source: DefaultsSource;
+}
+
+// Conservative v1 picks — review during PR. Hosted manifest at MANIFEST_URL
+// overrides these without requiring a release.
+const BAKED_IN: DefaultsManifest = {
+  version: 1,
+  defaults: {
+    "text-to-image": "fal-ai/flux/schnell",
+    "text-to-video": "fal-ai/minimax/hailuo-02/standard/text-to-video",
+    "text-to-audio-music": "fal-ai/cassetteai/cassette",
+    "text-to-audio-tts": "fal-ai/elevenlabs/tts/multilingual-v2",
+    "text-to-3d": "fal-ai/triposr",
+  },
+};
+
+function isFreshCache(fetchedAt: number, now: number): boolean {
+  return now - fetchedAt < TTL_MS;
+}
+
+export function isValidManifest(input: unknown): input is DefaultsManifest {
+  if (!input || typeof input !== "object") return false;
+  const m = input as Partial<DefaultsManifest>;
+  if (m.version !== 1) return false;
+  if (!m.defaults || typeof m.defaults !== "object") return false;
+  return true;
+}
+
+// Pure function: given current cache state and a fetched manifest (or null),
+// decide which endpoint to return and whether to update the cache. Exposed for
+// unit testing the fallback logic without touching disk or network.
+export function decideResolution(input: {
+  modality: Modality;
+  cached: DefaultsManifestCacheEntry | undefined;
+  fetched: DefaultsManifest | null;
+  now: number;
+}): {
+  result: ResolvedDefault;
+  saveCache?: DefaultsManifestCacheEntry;
+} {
+  const { modality, cached, fetched, now } = input;
+
+  if (cached && isFreshCache(cached.fetchedAt, now)) {
+    const endpoint = cached.manifest.defaults[modality];
+    if (endpoint) {
+      return { result: { endpoint_id: endpoint, source: "cached" } };
+    }
+  }
+
+  if (fetched) {
+    const endpoint = fetched.defaults[modality];
+    if (endpoint) {
+      return {
+        result: { endpoint_id: endpoint, source: "manifest" },
+        saveCache: { fetchedAt: now, manifest: fetched },
+      };
+    }
+  }
+
+  // Stale cache as a last-resort before baked-in (preserves the user's most
+  // recent server-side override even when the network is offline).
+  if (cached) {
+    const endpoint = cached.manifest.defaults[modality];
+    if (endpoint) {
+      return { result: { endpoint_id: endpoint, source: "cached" } };
+    }
+  }
+
+  return {
+    result: {
+      endpoint_id: BAKED_IN.defaults[modality],
+      source: "baked-in",
+    },
+  };
+}
+
+async function fetchManifest(): Promise<DefaultsManifest | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(MANIFEST_URL, {
+      signal: controller.signal,
+      headers: { "User-Agent": "genmedia-cli" },
+    });
+    if (!res.ok) return null;
+    const body = await res.json();
+    return isValidManifest(body) ? body : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function resolveDefaultEndpoint(
+  modality: Modality,
+): Promise<ResolvedDefault> {
+  const cfg = loadConfig();
+  const cached = cfg.defaultsManifestCache;
+  const now = Date.now();
+
+  // Skip fetch if cache is still fresh.
+  let fetched: DefaultsManifest | null = null;
+  if (!cached || !isFreshCache(cached.fetchedAt, now)) {
+    fetched = await fetchManifest();
+  }
+
+  const { result, saveCache } = decideResolution({
+    modality,
+    cached,
+    fetched,
+    now,
+  });
+
+  if (saveCache) {
+    saveConfig({ ...cfg, defaultsManifestCache: saveCache });
+  }
+
+  return result;
+}
+
+// Exported for tests / external introspection.
+export { BAKED_IN, FETCH_TIMEOUT_MS, MANIFEST_URL, TTL_MS };

--- a/src/lib/modality.test.ts
+++ b/src/lib/modality.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { classifyModality, modalityToCategory } from "./modality";
+
+describe("classifyModality", () => {
+  test("defaults to text-to-image for plain prompts", () => {
+    expect(classifyModality("a cat")).toBe("text-to-image");
+    expect(classifyModality("a cat on the moon, photorealistic")).toBe(
+      "text-to-image",
+    );
+    expect(classifyModality("diagram of a load balancer")).toBe(
+      "text-to-image",
+    );
+  });
+
+  test("routes video keywords to text-to-video", () => {
+    expect(classifyModality("a video of a robot dancing")).toBe(
+      "text-to-video",
+    );
+    expect(classifyModality("a 5-second clip of waves")).toBe("text-to-video");
+    expect(classifyModality("animation of a butterfly")).toBe("text-to-video");
+    expect(classifyModality("scene of a busy market at dusk")).toBe(
+      "text-to-video",
+    );
+  });
+
+  test("routes voice/narration keywords to TTS", () => {
+    expect(classifyModality("narrate this paragraph in a calm voice")).toBe(
+      "text-to-audio-tts",
+    );
+    expect(classifyModality("read aloud the introduction")).toBe(
+      "text-to-audio-tts",
+    );
+    expect(classifyModality("tts of the manifesto")).toBe("text-to-audio-tts");
+  });
+
+  test("routes music keywords to music", () => {
+    expect(classifyModality("a song about summer")).toBe("text-to-audio-music");
+    expect(classifyModality("upbeat instrumental track")).toBe(
+      "text-to-audio-music",
+    );
+    expect(classifyModality("a beat with heavy drums")).toBe(
+      "text-to-audio-music",
+    );
+  });
+
+  test("TTS takes precedence over music when both keywords appear", () => {
+    expect(classifyModality("say this song lyric out loud")).toBe(
+      "text-to-audio-tts",
+    );
+    expect(classifyModality("narrate the lyrics of this song")).toBe(
+      "text-to-audio-tts",
+    );
+  });
+
+  test("routes 3d keywords to text-to-3d", () => {
+    expect(classifyModality("a 3d model of a chair")).toBe("text-to-3d");
+    expect(classifyModality("export as gltf")).toBe("text-to-3d");
+    expect(classifyModality("low-poly mesh of a tree")).toBe("text-to-3d");
+  });
+
+  test("known false positives — documented behavior", () => {
+    // "a song bird" matches "song" → music. Override with explicit endpoint.
+    expect(classifyModality("a song bird painting")).toBe(
+      "text-to-audio-music",
+    );
+    // "language model" doesn't match 3d (correctly — only "3d model" pattern triggers).
+    expect(classifyModality("a diagram of a language model")).toBe(
+      "text-to-image",
+    );
+  });
+
+  test("is case-insensitive", () => {
+    expect(classifyModality("A VIDEO of a robot")).toBe("text-to-video");
+    expect(classifyModality("Narrate THIS")).toBe("text-to-audio-tts");
+  });
+});
+
+describe("modalityToCategory", () => {
+  test("maps to fal.ai catalog category strings", () => {
+    expect(modalityToCategory("text-to-image")).toBe("text-to-image");
+    expect(modalityToCategory("text-to-video")).toBe("text-to-video");
+    expect(modalityToCategory("text-to-audio-music")).toBe("text-to-audio");
+    expect(modalityToCategory("text-to-audio-tts")).toBe("text-to-speech");
+    expect(modalityToCategory("text-to-3d")).toBe("text-to-3d");
+  });
+});

--- a/src/lib/modality.ts
+++ b/src/lib/modality.ts
@@ -1,0 +1,76 @@
+export type Modality =
+  | "text-to-image"
+  | "text-to-video"
+  | "text-to-audio-music"
+  | "text-to-audio-tts"
+  | "text-to-3d";
+
+export const MODALITIES = [
+  "text-to-image",
+  "text-to-video",
+  "text-to-audio-music",
+  "text-to-audio-tts",
+  "text-to-3d",
+] as const satisfies readonly Modality[];
+
+interface Rule {
+  modality: Modality;
+  patterns: RegExp[];
+}
+
+// Order matters — first match wins. TTS before music so "say this song lyric" → tts.
+const RULES: Rule[] = [
+  {
+    modality: "text-to-3d",
+    patterns: [
+      /\b3d (?:model|mesh|asset|object|scene)\b/i,
+      /\b(?:mesh|gltf|glb|voxel)\b/i,
+    ],
+  },
+  {
+    modality: "text-to-video",
+    patterns: [
+      /\b(?:video|clip|animation|footage|reel|cinematic|cinemagraph)\b/i,
+      /\b(?:scene|shot|sequence) of\b/i,
+      /\bmotion (?:graphic|video)\b/i,
+    ],
+  },
+  {
+    modality: "text-to-audio-tts",
+    patterns: [
+      /\b(?:voice|voiceover|narrate|narration|narrator|tts)\b/i,
+      /\b(?:speak|say|read aloud|recite|announce)\b/i,
+    ],
+  },
+  {
+    modality: "text-to-audio-music",
+    patterns: [
+      /\b(?:song|music|track|melody|beat|instrumental|jingle|tune)\b/i,
+      /\blyric/i,
+    ],
+  },
+];
+
+export function classifyModality(prompt: string): Modality {
+  for (const rule of RULES) {
+    if (rule.patterns.some((re) => re.test(prompt))) {
+      return rule.modality;
+    }
+  }
+  return "text-to-image";
+}
+
+export function modalityToCategory(modality: Modality): string {
+  switch (modality) {
+    case "text-to-image":
+      return "text-to-image";
+    case "text-to-video":
+      return "text-to-video";
+    case "text-to-audio-music":
+      return "text-to-audio";
+    case "text-to-audio-tts":
+      return "text-to-speech";
+    case "text-to-3d":
+      return "text-to-3d";
+  }
+}

--- a/web/app/defaults.json/route.ts
+++ b/web/app/defaults.json/route.ts
@@ -1,0 +1,28 @@
+// Default model endpoint per modality. Served at https://genmedia.sh/defaults.json
+// and consumed by the CLI's smart-default routing (src/lib/defaults-manifest.ts).
+//
+// Keep these values in lockstep with `BAKED_IN` in the CLI source - the hosted
+// manifest is the override, the baked-in copy is the offline fallback. When
+// rolling new defaults: edit here AND in src/lib/defaults-manifest.ts so the
+// CLI ships a sane fallback for users on stale releases.
+
+export async function GET() {
+  return Response.json(
+    {
+      version: 1,
+      defaults: {
+        "text-to-image": "fal-ai/flux/schnell",
+        "text-to-video": "fal-ai/minimax/hailuo-02/standard/text-to-video",
+        "text-to-audio-music": "fal-ai/cassetteai/cassette",
+        "text-to-audio-tts": "fal-ai/elevenlabs/tts/multilingual-v2",
+        "text-to-3d": "fal-ai/triposr",
+      },
+    },
+    {
+      headers: {
+        "cache-control":
+          "public, max-age=0, s-maxage=300, stale-while-revalidate=3600",
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- `genmedia run "<prompt>"` now works with no model — the prompt is classified by modality and routed to a sensible default endpoint. Closes the "demo gap" (the "three seconds total" headline that didn't run today because `endpointId` was a required positional).
- `genmedia models "<query>"` auto-applies `--category` from the same classifier when none is set — agents get a focused result set instead of every modality.
- Defaults come from a hosted manifest at `https://genmedia.sh/defaults.json` (overridable via `GENMEDIA_DEFAULTS_URL`) so we can rev defaults without releasing the CLI. Baked-in fallback chain: fresh cache → hosted manifest → stale cache → baked-in. Answers the open question of who maintains the routing logic for "generate image" → which model? 

## Behavior

### `genmedia run`

| Invocation | Behavior |
|---|---|
| `genmedia run fal-ai/flux/dev --prompt "a cat"` | Existing path — explicit endpoint, no routing. |
| `genmedia run "a cat on the moon"` | Smart routing — positional treated as prompt (no `/`), classified to `text-to-image`, routed to default. |
| `genmedia run --prompt "a cat"` | Smart routing — `--prompt` triggers same routing. |
| `genmedia run` (no positional, no `--prompt`) | Exits 1 with usage hint. |

JSON output gains:
```json
"routed": { "modality": "text-to-image", "source": "baked-in", "from_prompt": "a cat" }
```
when smart routing fires; absent for explicit-endpoint invocations.

Pretty mode also writes a one-line `Routing → <modality> → <endpoint>` to stderr.

### `genmedia models`

When no `--category` is passed and there's a query, the modality classifier infers one. JSON output gains `inferred_category`. `--no-classify` disables. Explicit `--category` always wins.

## Modality classifier (`src/lib/modality.ts`)

5 modalities: `text-to-image` (default), `text-to-video`, `text-to-audio-music`, `text-to-audio-tts`, `text-to-3d`. ~60-line keyword scan, no LLM call (calling an LLM to classify before generating defeats the latency pitch). TTS checked before music so "say this song lyric" routes to TTS. One documented false positive: "a song bird" → music — override with explicit endpoint.

## Defaults manifest (`src/lib/defaults-manifest.ts`)

```json
{
  "version": 1,
  "defaults": {
    "text-to-image":      "fal-ai/flux/schnell",
    "text-to-video":      "fal-ai/minimax/hailuo-02/standard/text-to-video",
    "text-to-audio-music":"fal-ai/cassetteai/cassette",
    "text-to-audio-tts":  "fal-ai/elevenlabs/tts/multilingual-v2",
    "text-to-3d":         "fal-ai/triposr"
  }
}
```

**These are placeholder picks — please review during PR.** Anyone with sharper picks per modality, please flag — easy to swap.

Cache: `~/.genmedia/config.json` `defaultsManifestCache` field, 6h TTL, 1-second fetch timeout. Pure `decideResolution()` function isolates fallback logic for tests.

## Files

**New:**
- `src/lib/modality.ts` — classifier + `modalityToCategory` mapper
- `src/lib/defaults-manifest.ts` — fetch, cache, fallback
- `src/lib/modality.test.ts`, `src/lib/defaults-manifest.test.ts` — 19 tests

**Modified:**
- `src/commands/run.ts` — endpointId optional, prompt detection, routing, output
- `src/commands/models.ts` — auto-category, `--no-classify`
- `src/index.ts` — `--help` guard skips schema fetch for non-endpoint positionals; JSON help schema updated for both commands
- `src/lib/config.ts` — `defaultsManifestCache` field on `GenmediaConfig`

## Analytics

- `model_run` event extended with `routed: { modality, source }` so we can measure smart-routing adoption and which fallback path dominates (informs which endpoint to pick as default per modality).
- New `models_classified` event mirrors the existing `skills_searched` shape — fires when `models` auto-applies a category, with `query` and `inferred_category`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` (biome) — clean
- [x] `bun run build` — single binary compiles
- [x] `bun test src/lib/` — 19 tests pass (9 modality + 10 defaults-manifest)
- [x] **End-to-end against real fal.ai endpoints:**
  - [x] `genmedia run "tiny test image of a circle" --async --json` → routed to `fal-ai/flux/schnell`, real `request_id` returned, `routed` metadata present
  - [x] `genmedia run --prompt "..."` (no positional) → same routing path
  - [x] `genmedia run fal-ai/flux/schnell --prompt "..." --async --json` → existing path, no `routed` field
  - [x] `genmedia run "a cat" --help` → static help, no schema fetch (no 404)
  - [x] `genmedia run fal-ai/flux/schnell --help --json` → dynamic schema help still works
  - [x] `genmedia run --json` (nothing) → exits 1 with usage hint
  - [x] `genmedia models "text to image" --json` → `category` and `inferred_category` set
  - [x] `genmedia models "..." --no-classify --json` → no inference
  - [x] `genmedia models "..." --category text-to-video --json` → user category wins, no `inferred_category` in output
- [x] Manual smoke in a real Claude Code session — verify the agent picks up the new `genmedia run "<prompt>"` ergonomics from the JSON help schema

## Out of scope (follow-ups)

- **Deploy `defaults.json` to https://genmedia.sh/defaults.json** — until then, every smart-routed call reports `source: "baked-in"`. The CLI works correctly either way; the manifest deploy unlocks live updates without releases.
- **`--brief` JSON for `models`** — trims the result schema to ~500 tokens for agents. Adjacent context-savings win, ~half day. Pairs naturally with this auto-classify feature.
- **Image-to-X routing** — when `--image_url` is present and no endpoint, route to image-to-image defaults. V1 only handles text-to-X.
- **Locally-trained classifier** — keyword rules will misclassify some prompts. Watch the `models_classified` analytics for misclassifications first; only swap in a small tokenized model if the data warrants it.