### PR TITLE
feat(auth): minor robustness fixes to interactive login

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -24,7 +24,7 @@ export default defineCommand({
   async run({ args }) {
     if (!hasInteractiveTerminal()) {
       error("`genmedia auth login` requires an interactive terminal.", {
-        hint: "Run it locally, then copy ~/.genmedia/config.json across machines, or use FAL_KEY in non-interactive environments.",
+        hint: "Set FAL_KEY in non-interactive environments (CI, scripts, headless servers). Sessions are bound to the machine that signed in and cannot be copied across hosts.",
       });
     }
 

--- a/src/lib/auth/device.ts
+++ b/src/lib/auth/device.ts
@@ -52,10 +52,32 @@ export class DeviceFlowError extends Error {
 }
 
 export class RefreshFailedError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    public readonly terminal: boolean,
+    public readonly code?: string,
+  ) {
     super(message);
     this.name = "RefreshFailedError";
   }
+}
+
+// OAuth2 error codes that mean the refresh token will never succeed on retry.
+// See RFC 6749 §5.2. Network errors and 5xx/429 responses are transient.
+function isTerminalAuthError(
+  code: string | undefined,
+  status: number,
+): boolean {
+  switch (code) {
+    case "invalid_grant": // token revoked, expired, or rotated out
+    case "invalid_client": // client_id wrong / app deleted
+    case "unauthorized_client": // client not authorized for this grant
+    case "unsupported_grant_type": // grant misconfigured
+      return true;
+  }
+  if (status >= 500 || status === 429) return false; // server-side / rate-limited
+  if (status >= 400) return true; // other 4xx: malformed request, won't fix
+  return false;
 }
 
 function debug(msg: string): void {
@@ -178,6 +200,8 @@ export async function refreshTokens(
       `Refresh failed (${result.status}): ${
         err.error_description ?? err.error ?? "unknown"
       }`,
+      isTerminalAuthError(err.error, result.status),
+      err.error,
     );
   }
   return result.data as TokenResponse;

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -52,7 +52,7 @@ export function decodeJwtExp(token: string): number | null {
     const padded = parts[1] + "=".repeat(padLen);
     const json = Buffer.from(
       padded.replace(/-/g, "+").replace(/_/g, "/"),
-      "base64"
+      "base64",
     ).toString("utf-8");
     const claims = JSON.parse(json) as { exp?: number };
     return typeof claims.exp === "number" ? claims.exp * 1000 : null;

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -103,7 +103,8 @@ async function withLock<T>(fn: () => Promise<T>): Promise<T> {
 
   if (fd === null) {
     throw new RefreshFailedError(
-      "Could not acquire auth lock — another genmedia process appears hung. Retry shortly."
+      "Could not acquire auth lock — another genmedia process appears hung. Retry shortly.",
+      false, // transient: another process is racing us; retry should work
     );
   }
 
@@ -166,8 +167,12 @@ export async function getValidAccessToken(opts?: {
           return next.access_token;
         } catch (e) {
           if (e instanceof RefreshFailedError) {
-            debug(`refresh failed: ${e.message}`);
-            clearSession();
+            if (e.terminal) {
+              debug(`refresh terminal: ${e.message}`);
+              clearSession();
+              return null;
+            }
+            debug(`refresh transient: ${e.message} (keeping session)`);
             return null;
           }
           throw e;

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,4 +1,4 @@
-import { closeSync, existsSync, openSync, unlinkSync } from "node:fs";
+import { closeSync, existsSync, openSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import {
   type AuthSession,
@@ -14,8 +14,15 @@ import { RefreshFailedError, refreshTokens } from "./device";
 export type { AuthSession } from "../config";
 
 const LOCK_FILE = join(CONFIG_DIR, "auth.lock");
-const LOCK_TIMEOUT_MS = 2000;
-const LOCK_POLL_MS = 50;
+// Total time we wait for another process's lock before treating the situation
+// as pathological. Longer than any legitimate refresh round-trip — the only
+// reason to wait this long is if the other process is genuinely doing work.
+const LOCK_WAIT_MS = 30_000;
+// A lock file older than this is almost certainly orphaned by a crashed
+// process. Legitimate holders complete in seconds; STALE_LOCK_MS leaves a
+// generous margin for slow networks, paused VMs, etc.
+const STALE_LOCK_MS = 30_000;
+const LOCK_POLL_MS = 100;
 
 function debug(msg: string): void {
   if (isAuthDebug()) process.stderr.write(`[auth] ${msg}\n`);
@@ -45,7 +52,7 @@ export function decodeJwtExp(token: string): number | null {
     const padded = parts[1] + "=".repeat(padLen);
     const json = Buffer.from(
       padded.replace(/-/g, "+").replace(/_/g, "/"),
-      "base64",
+      "base64"
     ).toString("utf-8");
     const claims = JSON.parse(json) as { exp?: number };
     return typeof claims.exp === "number" ? claims.exp * 1000 : null;
@@ -66,20 +73,40 @@ export function computeExpiresAt(opts: {
 }
 
 async function withLock<T>(fn: () => Promise<T>): Promise<T> {
-  const start = Date.now();
+  const deadline = Date.now() + LOCK_WAIT_MS;
   let fd: number | null = null;
-  while (Date.now() - start < LOCK_TIMEOUT_MS) {
+
+  while (Date.now() < deadline) {
     try {
       fd = openSync(LOCK_FILE, "wx");
       break;
     } catch {
+      // Lock exists — check if it's stale (mtime older than threshold).
+      try {
+        const { mtimeMs } = statSync(LOCK_FILE);
+        if (Date.now() - mtimeMs > STALE_LOCK_MS) {
+          debug("removing stale auth lock");
+          try {
+            unlinkSync(LOCK_FILE);
+          } catch {
+            // Raced with another reclaimer — fall through and retry the open.
+          }
+          continue;
+        }
+      } catch {
+        // Lock file vanished (likely released) between the failed open and the stat — retry the open.
+        continue;
+      }
       await new Promise((r) => setTimeout(r, LOCK_POLL_MS));
     }
   }
+
   if (fd === null) {
-    debug("lock acquire timed out, proceeding without lock");
-    return fn();
+    throw new RefreshFailedError(
+      "Could not acquire auth lock — another genmedia process appears hung. Retry shortly."
+    );
   }
+
   try {
     return await fn();
   } finally {


### PR DESCRIPTION
## Summary

Hardens auth-session handling on three fronts, in response to an audit against `gh` and `auth0-cli`'s implementations. Each fix was reproduced from a runnable script before the change and re-verified after.

## Fixes

### 1. Misleading "copy config across machines" hint

**Bug:** `src/commands/auth/login.ts:28` told users to copy `~/.genmedia/config.json` to other machines as a workaround for non-TTY environments. But the session blob is encrypted with a key derived from `hostname:username:genmedia` (`src/lib/config.ts:64`), so the file is undecryptable anywhere except the originating host.

**Repro:** Read `~/.genmedia/config.json`, attempt AES-GCM decrypt with three keys — the real machine's `hostname+username`, a different hostname, and a different username. Real key decrypts; the other two return `FAIL`.

**Fix:** Updated the hint to direct non-interactive users to `FAL_KEY` instead, and to state explicitly that sessions are bound to the host.

### 2. Lock-acquire timeout silently fell through to "no lock"

**Bug:** `withLock` in `src/lib/auth/session.ts` polled for 2s, and if it couldn't acquire the lock, ran the refresh anyway without the lock — defeating the lock's purpose. Two concurrent refreshes would both burn the same refresh token and one would lose to `invalid_grant`.

**Repro:** `touch ~/.genmedia/auth.lock` (hold the lock externally), expire the local access token, call `getValidAccessToken()`. Confirmed `[auth] lock acquire timed out, proceeding without lock` plus a successful refresh — proof that the refresh ran unprotected.

**Fix:** Replaced the fallthrough with stale-lock detection via `mtime`. Locks older than 30s are reclaimed as orphans; fresher locks are waited out (up to 30s); genuine contention now throws `RefreshFailedError(terminal: false)` instead of silently running unprotected.

**Verified (3 cases):**

| Scenario | Before | After |
|---|---|---|
| Healthy refresh (no lock) | works ~1.3s | works ~1.3s |
| Stale lock (>30s mtime) | falls through, runs unlocked | reclaimed via `[auth] removing stale auth lock` |
| Fresh lock held externally | falls through after 2s | throws `RefreshFailedError` after 30s wait |

### 3. Transient refresh failures cleared the session

**Bug:** The `RefreshFailedError` catch in `getValidAccessToken` called `clearSession()` on *any* non-OK HTTP response from Auth0 — including 503/429/5xx. A single transient outage would log the user out.

**Repro:** Mocked `fetch` to return 503 on `/oauth/token`, forced a refresh. Result: session wiped, `signed_in: false`. Same flow with `invalid_grant` (400) — also cleared. The two cases were indistinguishable.

**Fix:**
- `device.ts`: `RefreshFailedError` now carries `terminal: boolean` + optional `code: string`. New `isTerminalAuthError(code, status)` classifier based on RFC 6749 §5.2 (`invalid_grant`, `invalid_client`, etc. → terminal; 5xx/429 → transient).
- `session.ts`: catch handler only calls `clearSession()` on terminal errors; transient errors keep the session and return `null` so the next call retries.

**Verified:**

| Scenario | After |
|---|---|
| 503 / 429 / network blip | session retained, `null` returned |
| `invalid_grant` | session cleared |

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run build` — passes
- [x] `auth login` → `auth status` → `auth logout` round-trip works end-to-end
- [x] Run a REST command (e.g. `genmedia models list`) with `FAL_KEY=` unset — uses session
- [x] Run with `FAL_KEY=<key>` set — env takes precedence over session

## Follow-ups (not in this PR)

- Audit #4: SDK middleware doesn't refresh on 401 (REST path via `platformFetch` does)
- Audit #5+: token storage (move to OS keychain), atomic config writes, `setSession`/`clearSession` lock-protection, stale-lock reclaim tightening, default `auth logout` revocation
