### PR TITLE
feat: add `gallery` command for per-session HTML preview of generated assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Shows the current version and flags any known update (populated by the backgroun
 Every successful `genmedia run` (and `genmedia status --download`) records its outputs into a per-session, self-contained static HTML page under `~/.genmedia/gallery/sessions/<session_id>/index.html`. The page aggregates every image / video / audio / 3D asset produced inside one agent session — across many runs and many endpoints — into a filterable grid with a lightbox view. No server, no dependencies, opens straight from `file://`.
 
 ```bash
-genmedia gallery                          # print { session_id, path, url } for the current session
-genmedia gallery info                     # same as above (explicit form)
+genmedia gallery                          # pretty TTY: prints `→ Open: <url>`. JSON / non-TTY: full info payload.
+genmedia gallery --json                   # structured info payload, agent-safe
+genmedia gallery info                     # full info payload, even from a TTY (devs)
 genmedia gallery open                     # open the all-sessions index in the default browser
 genmedia gallery open current             # open the current session
 genmedia gallery open latest              # open the most-recently recorded session (works across shells)
@@ -175,6 +176,9 @@ genmedia gallery open <session_id>        # open a specific session
 genmedia gallery open latest --print      # resolve path/url without launching the browser
 genmedia gallery list                     # list every recorded session (newest first, JSON-friendly)
 genmedia gallery list --limit 10          # cap the list (default: 50)
+genmedia gallery rename --label "demo run"        # rename the current session (cosmetic — id stays the same)
+genmedia gallery rename latest --label "x"        # rename the most-recent session
+genmedia gallery rename <session_id> --clear      # remove a session's label
 genmedia gallery clear --yes              # delete the current session (--yes is required)
 genmedia gallery clear latest --yes       # delete the most-recently recorded session
 genmedia gallery clear <session_id> --yes # delete a specific session

--- a/README.md
+++ b/README.md
@@ -161,6 +161,59 @@ genmedia version
 
 Shows the current version and flags any known update (populated by the background checker).
 
+### `gallery` — Browse a per-session HTML preview of generated assets
+
+Every successful `genmedia run` (and `genmedia status --download`) records its outputs into a per-session, self-contained static HTML page under `~/.genmedia/gallery/sessions/<session_id>/index.html`. The page aggregates every image / video / audio / 3D asset produced inside one agent session — across many runs and many endpoints — into a filterable grid with a lightbox view. No server, no dependencies, opens straight from `file://`.
+
+```bash
+genmedia gallery                          # print { session_id, path, url } for the current session
+genmedia gallery info                     # same as above (explicit form)
+genmedia gallery open                     # open the all-sessions index in the default browser
+genmedia gallery open current             # open the current session
+genmedia gallery open latest              # open the most-recently recorded session (works across shells)
+genmedia gallery open <session_id>        # open a specific session
+genmedia gallery open latest --print      # resolve path/url without launching the browser
+genmedia gallery list                     # list every recorded session (newest first, JSON-friendly)
+genmedia gallery list --limit 10          # cap the list (default: 50)
+genmedia gallery clear --yes              # delete the current session (--yes is required)
+genmedia gallery clear latest --yes       # delete the most-recently recorded session
+genmedia gallery clear <session_id> --yes # delete a specific session
+genmedia gallery clear all --yes          # delete every recorded session
+```
+
+The page auto-refreshes via a tiny client-side poll on `./data.json` while a session is "live" (updated in the last 5 min), so new runs land in the open tab without a manual reload.
+
+> `gallery clear` always requires `--yes` and never prompts interactively — same shape for agents and humans. `GENMEDIA_NO_GALLERY=1` only disables *recording*; `list` / `open` / `clear` still work so you can inspect or purge prior galleries.
+
+The `run` and `status --download` responses include the gallery info too:
+
+```json
+{
+  "status": "completed",
+  "endpoint_id": "fal-ai/flux/dev",
+  "request_id": "…",
+  "gallery": {
+    "session_id": "a1b2c3d4e5f6",
+    "path": "/Users/you/.genmedia/gallery/sessions/a1b2c3d4e5f6/index.html",
+    "url": "file:///Users/you/.genmedia/gallery/sessions/a1b2c3d4e5f6/index.html"
+  }
+}
+```
+
+**Session detection (agent-agnostic).** The session id is resolved in this order, so the gallery groups outputs correctly across Claude Code, Codex, Cursor, Amp, Gemini, Aider, and anything else:
+
+1. `GENMEDIA_SESSION_ID` — explicit override (e.g. set from a hook script).
+2. Per-agent env vars: `CODEX_THREAD_ID`, `CLAUDE_SESSION_ID`, `AMP_THREAD_ID`, `CURSOR_TRACE_ID`.
+3. **Process-tree walk** — looks for a known agent binary (claude, codex, cursor, amp, gemini, copilot, opencode, aider, cline) in the ancestor chain via `ps -e`. Critical for Claude Code, whose `Bash` tool spawns a fresh shell per call: `process.ppid` changes every invocation, but the Claude process itself lives for the whole conversation and becomes the stable anchor.
+4. Terminal-level: `TERM_SESSION_ID` / `ITERM_SESSION_ID` / `WT_SESSION` / `TMUX_PANE`.
+5. Fallback: a deterministic hash of `<agent>:<ppid>`.
+
+| Env var | Description |
+|---|---|
+| `GENMEDIA_NO_GALLERY=1` | Disable gallery recording and rendering entirely. |
+| `GENMEDIA_SESSION_ID=<anchor>` | Force a specific session id (any string; it's hashed into the on-disk slug). |
+| `GENMEDIA_GALLERY_RETENTION_DAYS=<n>` | Prune session directories older than `n` days (default: 60). |
+
 ### `update` — Check for and apply updates
 
 ```bash

--- a/src/commands/gallery/clear.ts
+++ b/src/commands/gallery/clear.ts
@@ -1,0 +1,91 @@
+import { defineCommand } from "citty";
+import {
+  clearGallery,
+  galleryPaths,
+  resolveLatestSessionId,
+} from "../../lib/gallery";
+import { error, output } from "../../lib/output";
+import { getSessionContext } from "../../lib/session";
+
+export default defineCommand({
+  meta: {
+    name: "clear",
+    description:
+      "Delete recorded gallery sessions. Always requires --yes (no interactive prompt).",
+  },
+  args: {
+    target: {
+      type: "positional",
+      required: false,
+      description:
+        'Target: "current" (default), "latest", "all", or a specific <session_id>',
+    },
+    yes: {
+      type: "boolean",
+      description:
+        "Required confirmation flag — clears are destructive and irreversible",
+    },
+  },
+  async run({ args }) {
+    const target = (args.target ?? "current").trim();
+
+    if (!args.yes) {
+      error("`gallery clear` is destructive — pass --yes to confirm.", {
+        examples: [
+          "genmedia gallery clear --yes",
+          "genmedia gallery clear latest --yes",
+          "genmedia gallery clear all --yes",
+        ],
+      });
+    }
+
+    let sessionId: string | null = null;
+    let all = false;
+    let resolvedSource: "current" | "latest" | "explicit" | "all" = "current";
+
+    if (target === "all") {
+      all = true;
+      resolvedSource = "all";
+    } else if (target === "latest") {
+      sessionId = resolveLatestSessionId();
+      resolvedSource = "latest";
+      if (!sessionId) {
+        output(
+          {
+            scope: "clear",
+            target: "latest",
+            cleared: [],
+            session_id: null,
+            note: "No recorded sessions to clear.",
+          },
+          { view: "default" },
+        );
+        return;
+      }
+    } else if (target === "current" || target === "") {
+      sessionId = getSessionContext().id;
+      resolvedSource = "current";
+    } else {
+      sessionId = target;
+      resolvedSource = "explicit";
+    }
+
+    const result = all
+      ? clearGallery({ all: true })
+      : clearGallery({ sessionId: sessionId ?? undefined });
+
+    output(
+      {
+        scope: "clear",
+        target: resolvedSource,
+        ...(sessionId !== null ? { session_id: sessionId } : {}),
+        ...(sessionId !== null && !all
+          ? { url: galleryPaths(sessionId).index_url }
+          : {}),
+        cleared: result.cleared,
+        cleared_count: result.cleared.length,
+      },
+      { view: "default" },
+    );
+  },
+});

--- a/src/commands/gallery/gallery.test.ts
+++ b/src/commands/gallery/gallery.test.ts
@@ -1,0 +1,244 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearGallery,
+  galleryDir,
+  galleryPaths,
+  listSessions,
+  readLastSession,
+  recordRun,
+  regenerateRootIndexHtml,
+  regenerateSessionHtml,
+  resolveLatestSessionId,
+  rootIndexPath,
+  rootIndexUrl,
+  sessionsDir,
+  setGalleryRoot,
+} from "../../lib/gallery";
+import type { SessionContext } from "../../lib/session";
+import { parseLimit } from "./list";
+import { resolveTarget } from "./shared";
+
+function fakeCtx(overrides: Partial<SessionContext> = {}): SessionContext {
+  return {
+    id: "ctx-session-id",
+    source: "fallback",
+    agent: "test",
+    agentHost: null,
+    anchor: "test:1",
+    startedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeRun(suffix = "1") {
+  return {
+    ts: Date.now(),
+    request_id: `req-${suffix}`,
+    endpoint_id: "fal-ai/test",
+    modality: null,
+    prompt: null,
+    duration_ms: null,
+    files: [
+      {
+        path: null,
+        url: `https://cdn.example.com/${suffix}.png`,
+        size_bytes: null,
+        kind: "image" as const,
+        json_path: `images[${suffix}]`,
+      },
+    ],
+  };
+}
+
+describe("parseLimit", () => {
+  test("defaults to 50 when undefined or empty", () => {
+    expect(parseLimit(undefined)).toBe(50);
+    expect(parseLimit("")).toBe(50);
+  });
+  test("accepts positive integers", () => {
+    expect(parseLimit("1")).toBe(1);
+    expect(parseLimit("20")).toBe(20);
+  });
+  test("returns null for non-positive, non-integer, and non-numeric inputs", () => {
+    expect(parseLimit("0")).toBeNull();
+    expect(parseLimit("-3")).toBeNull();
+    expect(parseLimit("1.5")).toBeNull();
+    expect(parseLimit("abc")).toBeNull();
+    expect(parseLimit("Infinity")).toBeNull();
+    expect(parseLimit("NaN")).toBeNull();
+  });
+});
+
+describe("resolveTarget (pure paths)", () => {
+  test("undefined / empty / 'current' all resolve to current session", () => {
+    const ctx = fakeCtx({ id: "sess-abc" });
+    for (const t of [undefined, "", "current"]) {
+      const r = resolveTarget(t, ctx);
+      expect(r.kind).toBe("session");
+      if (r.kind === "session") {
+        expect(r.session_id).toBe("sess-abc");
+        expect(r.source).toBe("current");
+      }
+    }
+  });
+
+  test("'index' resolves to the all-sessions index target", () => {
+    const r = resolveTarget("index", fakeCtx());
+    expect(r.kind).toBe("index");
+    if (r.kind === "index") {
+      expect(r.url.startsWith("file://")).toBe(true);
+      expect(r.path.endsWith("index.html")).toBe(true);
+    }
+  });
+
+  test("unknown string is treated as an explicit session id (not validated)", () => {
+    const r = resolveTarget("doesnt-exist-xyz", fakeCtx());
+    expect(r.kind).toBe("session");
+    if (r.kind === "session") {
+      expect(r.source).toBe("explicit");
+      expect(r.session_id).toBe("doesnt-exist-xyz");
+    }
+  });
+});
+
+describe("gallery storage (redirected root)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "genmedia-gallery-test-"));
+    setGalleryRoot(tmp);
+  });
+
+  afterAll(() => {
+    setGalleryRoot(null);
+  });
+
+  test("path helpers honor the override", () => {
+    expect(galleryDir()).toBe(tmp);
+    expect(sessionsDir()).toBe(join(tmp, "sessions"));
+    expect(rootIndexPath()).toBe(join(tmp, "index.html"));
+    expect(rootIndexUrl().startsWith("file://")).toBe(true);
+    expect(rootIndexUrl().endsWith("/index.html")).toBe(true);
+  });
+
+  test("readLastSession + resolveLatestSessionId return null on empty root", () => {
+    expect(readLastSession()).toBeNull();
+    expect(resolveLatestSessionId()).toBeNull();
+  });
+
+  test("resolveTarget('latest') errors out when no sessions exist", () => {
+    const r = resolveTarget("latest", fakeCtx());
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") {
+      expect(r.reason).toBe("latest-empty");
+    }
+  });
+
+  test("recordRun stamps the last-session pointer", () => {
+    const paths = recordRun(makeRun("a"));
+    expect(paths).not.toBeNull();
+    const last = readLastSession();
+    expect(last).not.toBeNull();
+    expect(last?.session_id).toBe(paths?.session_id ?? "");
+    expect(typeof last?.updated_at).toBe("number");
+  });
+
+  test("resolveLatestSessionId resolves to the just-recorded session", () => {
+    const paths = recordRun(makeRun("a"));
+    const id = resolveLatestSessionId();
+    expect(id).toBe(paths?.session_id ?? null);
+    // And resolveTarget('latest') is no longer an error.
+    const r = resolveTarget("latest", fakeCtx({ id: "unrelated" }));
+    expect(r.kind).toBe("session");
+    if (r.kind === "session") {
+      expect(r.source).toBe("latest");
+      expect(r.session_id).toBe(paths?.session_id ?? "");
+    }
+  });
+
+  test("clearGallery({ all: true }) drops pointer and clears every session", () => {
+    recordRun(makeRun("a"));
+    expect(readLastSession()).not.toBeNull();
+    const before = listSessions();
+    expect(before.length).toBeGreaterThan(0);
+
+    const result = clearGallery({ all: true });
+    expect(result.cleared.length).toBe(before.length);
+    expect(readLastSession()).toBeNull();
+    expect(listSessions().length).toBe(0);
+  });
+
+  test("clearGallery({ sessionId }) only drops pointer when ids match", () => {
+    const paths = recordRun(makeRun("a"));
+    const id = paths?.session_id ?? "";
+
+    // Clearing a different id leaves the pointer alone.
+    clearGallery({ sessionId: "some-other-id" });
+    expect(readLastSession()?.session_id).toBe(id);
+
+    // Clearing the pointed-to id removes the pointer.
+    clearGallery({ sessionId: id });
+    expect(readLastSession()).toBeNull();
+  });
+
+  test("regenerateSessionHtml rewrites stale HTML from data.json", () => {
+    const paths = recordRun(makeRun("a"));
+    const id = paths?.session_id ?? "";
+
+    // Simulate a stale HTML left over from an older CLI version.
+    const sessionPaths = galleryPaths(id);
+    writeFileSync(sessionPaths.index_path, "<!-- stale -->", "utf-8");
+    expect(readFileSync(sessionPaths.index_path, "utf-8")).toBe(
+      "<!-- stale -->",
+    );
+
+    expect(regenerateSessionHtml(id)).toBe(true);
+    const fresh = readFileSync(sessionPaths.index_path, "utf-8");
+    expect(fresh).toStartWith("<!doctype html>");
+    expect(fresh).toContain(`"session_id":"${id}"`);
+  });
+
+  test("regenerateSessionHtml is a no-op for unknown ids", () => {
+    expect(regenerateSessionHtml("never-recorded")).toBe(false);
+  });
+
+  test("regenerateRootIndexHtml rewrites the root index", () => {
+    recordRun(makeRun("a"));
+    writeFileSync(rootIndexPath(), "<!-- stale root -->", "utf-8");
+    expect(readFileSync(rootIndexPath(), "utf-8")).toBe("<!-- stale root -->");
+
+    expect(regenerateRootIndexHtml()).toBe(true);
+    const fresh = readFileSync(rootIndexPath(), "utf-8");
+    expect(fresh).toStartWith("<!doctype html>");
+    expect(fresh).toContain('id="sessions-grid"');
+  });
+
+  test("GENMEDIA_NO_GALLERY blocks writes but not reads/clears", () => {
+    recordRun(makeRun("a"));
+    expect(listSessions().length).toBe(1);
+
+    const prev = process.env.GENMEDIA_NO_GALLERY;
+    process.env.GENMEDIA_NO_GALLERY = "1";
+    try {
+      // Reads still work — that's the whole point of the fix.
+      expect(listSessions().length).toBe(1);
+      expect(readLastSession()).not.toBeNull();
+
+      // Writes are refused.
+      const blocked = recordRun(makeRun("b"));
+      expect(blocked).toBeNull();
+      expect(listSessions().length).toBe(1);
+
+      // Clear remains available so users can purge after disabling.
+      const cleared = clearGallery({ all: true });
+      expect(cleared.cleared.length).toBe(1);
+      expect(listSessions().length).toBe(0);
+    } finally {
+      if (prev === undefined) delete process.env.GENMEDIA_NO_GALLERY;
+      else process.env.GENMEDIA_NO_GALLERY = prev;
+    }
+  });
+});

--- a/src/commands/gallery/gallery.test.ts
+++ b/src/commands/gallery/gallery.test.ts
@@ -6,11 +6,14 @@ import {
   clearGallery,
   galleryDir,
   galleryPaths,
+  LABEL_MAX_LENGTH,
   listSessions,
+  type RecordRunInput,
   readLastSession,
   recordRun,
   regenerateRootIndexHtml,
   regenerateSessionHtml,
+  renameSession,
   resolveLatestSessionId,
   rootIndexPath,
   rootIndexUrl,
@@ -33,7 +36,7 @@ function fakeCtx(overrides: Partial<SessionContext> = {}): SessionContext {
   };
 }
 
-function makeRun(suffix = "1") {
+function makeRun(suffix = "1"): RecordRunInput {
   return {
     ts: Date.now(),
     request_id: `req-${suffix}`,
@@ -46,7 +49,7 @@ function makeRun(suffix = "1") {
         path: null,
         url: `https://cdn.example.com/${suffix}.png`,
         size_bytes: null,
-        kind: "image" as const,
+        kind: "image",
         json_path: `images[${suffix}]`,
       },
     ],
@@ -214,6 +217,114 @@ describe("gallery storage (redirected root)", () => {
     const fresh = readFileSync(rootIndexPath(), "utf-8");
     expect(fresh).toStartWith("<!doctype html>");
     expect(fresh).toContain('id="sessions-grid"');
+  });
+
+  test("listSessions previews include all kinds FIFO, capped at 4", () => {
+    // image, video, audio, model (in that order). All four kinds fit in
+    // the 4-slot cap and appear in chronological FIFO order.
+    recordRun(makeRun("img-a"));
+    recordRun({
+      ts: Date.now(),
+      request_id: "vid-1",
+      endpoint_id: "fal-ai/test",
+      modality: null,
+      prompt: null,
+      duration_ms: null,
+      files: [
+        {
+          path: "/tmp/clip.mp4",
+          url: "https://cdn.example.com/clip.mp4",
+          size_bytes: null,
+          kind: "video",
+          json_path: "video",
+        },
+      ],
+    });
+    recordRun({
+      ts: Date.now(),
+      request_id: "audio-1",
+      endpoint_id: "fal-ai/test",
+      modality: null,
+      prompt: null,
+      duration_ms: null,
+      files: [
+        {
+          path: null,
+          url: "https://cdn.example.com/voice.mp3",
+          size_bytes: null,
+          kind: "audio",
+          json_path: "audio[0]",
+        },
+      ],
+    });
+    recordRun({
+      ts: Date.now(),
+      request_id: "model-1",
+      endpoint_id: "fal-ai/test",
+      modality: null,
+      prompt: null,
+      duration_ms: null,
+      files: [
+        {
+          path: null,
+          url: "https://cdn.example.com/asset.glb",
+          size_bytes: null,
+          kind: "model",
+          json_path: "model",
+        },
+      ],
+    });
+    recordRun(makeRun("img-b")); // would be 5th — capped out
+
+    const previews = listSessions()[0].previews;
+    expect(previews.length).toBe(4);
+    expect(previews.map((p) => p.kind)).toEqual([
+      "image",
+      "video",
+      "audio",
+      "model",
+    ]);
+    expect(previews[3]).toEqual({
+      kind: "model",
+      file: null,
+      url: "https://cdn.example.com/asset.glb",
+    });
+  });
+
+  test("renameSession sets, trims, clears, and exposes label via listSessions", () => {
+    const paths = recordRun(makeRun("a"));
+    const id = paths?.session_id ?? "";
+
+    // Set
+    const ok = renameSession(id, "  fluffy dog batch  ");
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.label).toBe("fluffy dog batch");
+    expect(listSessions()[0].label).toBe("fluffy dog batch");
+
+    // Clear via null
+    const cleared = renameSession(id, null);
+    expect(cleared.ok).toBe(true);
+    if (cleared.ok) expect(cleared.label).toBeNull();
+    expect(listSessions()[0].label).toBeNull();
+
+    // Clear via empty string
+    renameSession(id, "x");
+    const cleared2 = renameSession(id, "   ");
+    expect(cleared2.ok).toBe(true);
+    if (cleared2.ok) expect(cleared2.label).toBeNull();
+  });
+
+  test("renameSession rejects too-long labels and unknown ids", () => {
+    const paths = recordRun(makeRun("a"));
+    const id = paths?.session_id ?? "";
+
+    const tooLong = renameSession(id, "x".repeat(LABEL_MAX_LENGTH + 1));
+    expect(tooLong.ok).toBe(false);
+    if (!tooLong.ok) expect(tooLong.reason).toBe("too-long");
+
+    const missing = renameSession("does-not-exist", "anything");
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.reason).toBe("not-found");
   });
 
   test("GENMEDIA_NO_GALLERY blocks writes but not reads/clears", () => {

--- a/src/commands/gallery/index.ts
+++ b/src/commands/gallery/index.ts
@@ -15,6 +15,7 @@ export default defineCommand({
     info: () => import("./info").then((m) => m.default),
     open: () => import("./open").then((m) => m.default),
     list: () => import("./list").then((m) => m.default),
+    rename: () => import("./rename").then((m) => m.default),
     clear: () => import("./clear").then((m) => m.default),
   },
 });

--- a/src/commands/gallery/index.ts
+++ b/src/commands/gallery/index.ts
@@ -1,0 +1,20 @@
+import { defineCommand } from "citty";
+
+// citty quirk: a parent command's `run` fires *in addition to* the matched
+// subcommand's run. Using `default: "info"` plus only `subCommands` is the
+// supported way to have a sensible behavior for the bare `genmedia gallery`
+// command without double-printing.
+export default defineCommand({
+  meta: {
+    name: "gallery",
+    description:
+      "Show or manage per-session HTML galleries of generated assets (file:// URL, no server)",
+  },
+  default: "info",
+  subCommands: {
+    info: () => import("./info").then((m) => m.default),
+    open: () => import("./open").then((m) => m.default),
+    list: () => import("./list").then((m) => m.default),
+    clear: () => import("./clear").then((m) => m.default),
+  },
+});

--- a/src/commands/gallery/info.ts
+++ b/src/commands/gallery/info.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "node:fs";
+import { defineCommand } from "citty";
+import {
+  galleryPaths,
+  isGalleryDisabled,
+  readLastSession,
+  regenerateRootIndexHtml,
+  regenerateSessionHtml,
+  rootIndexUrl,
+} from "../../lib/gallery";
+import { output } from "../../lib/output";
+import { getSessionContext } from "../../lib/session";
+
+// Default subcommand. Prints the current session's gallery info — never
+// destructive, never opens a browser. Use `gallery open` for that.
+export default defineCommand({
+  meta: {
+    name: "info",
+    description:
+      "Print the current session's gallery info (path, url, exists). Default subcommand.",
+  },
+  async run() {
+    const ctx = getSessionContext();
+    const paths = galleryPaths(ctx.id);
+    // Both URLs we emit point at on-disk HTML — refresh them against the
+    // current template so anyone clicking through gets the latest UI.
+    regenerateSessionHtml(ctx.id);
+    regenerateRootIndexHtml();
+    const exists = existsSync(paths.index_path);
+    const last = readLastSession();
+
+    const hasLatestElsewhere =
+      !exists && last !== null && last.session_id !== ctx.id;
+
+    output(
+      {
+        scope: "session",
+        session_id: ctx.id,
+        session_source: ctx.source,
+        agent: ctx.agent,
+        agent_host: ctx.agentHost,
+        path: paths.index_path,
+        url: paths.index_url,
+        exists,
+        recording_disabled: isGalleryDisabled(),
+        index_url: rootIndexUrl(),
+        ...(hasLatestElsewhere
+          ? {
+              latest: {
+                session_id: last.session_id,
+                agent: last.agent,
+                updated_at: last.updated_at,
+                hint: "Open it with `genmedia gallery open latest`.",
+              },
+            }
+          : {}),
+        ...(exists
+          ? {}
+          : {
+              hint: hasLatestElsewhere
+                ? "This shell resolves to a different session than your last recording. Try `genmedia gallery open latest`."
+                : "No assets have been recorded for this session yet — run a model first.",
+            }),
+      },
+      { view: "default" },
+    );
+  },
+});

--- a/src/commands/gallery/info.ts
+++ b/src/commands/gallery/info.ts
@@ -8,61 +8,90 @@ import {
   regenerateSessionHtml,
   rootIndexUrl,
 } from "../../lib/gallery";
-import { output } from "../../lib/output";
+import { isJsonOutput, output } from "../../lib/output";
 import { getSessionContext } from "../../lib/session";
+import { colors } from "../../lib/ui";
 
-// Default subcommand. Prints the current session's gallery info — never
-// destructive, never opens a browser. Use `gallery open` for that.
 export default defineCommand({
   meta: {
     name: "info",
     description:
-      "Print the current session's gallery info (path, url, exists). Default subcommand.",
+      "Show gallery info. `gallery info` (explicit) or `--json` prints the full payload + open hint; bare `gallery` in pretty TTY prints just the hint.",
   },
   async run() {
     const ctx = getSessionContext();
     const paths = galleryPaths(ctx.id);
-    // Both URLs we emit point at on-disk HTML — refresh them against the
-    // current template so anyone clicking through gets the latest UI.
+    // Refresh on-disk HTML so the URL we hand back uses the current template.
     regenerateSessionHtml(ctx.id);
     regenerateRootIndexHtml();
     const exists = existsSync(paths.index_path);
     const last = readLastSession();
-
     const hasLatestElsewhere =
       !exists && last !== null && last.session_id !== ctx.id;
 
-    output(
-      {
-        scope: "session",
-        session_id: ctx.id,
-        session_source: ctx.source,
-        agent: ctx.agent,
-        agent_host: ctx.agentHost,
-        path: paths.index_path,
-        url: paths.index_url,
-        exists,
-        recording_disabled: isGalleryDisabled(),
-        index_url: rootIndexUrl(),
-        ...(hasLatestElsewhere
-          ? {
-              latest: {
-                session_id: last.session_id,
-                agent: last.agent,
-                updated_at: last.updated_at,
-                hint: "Open it with `genmedia gallery open latest`.",
-              },
-            }
-          : {}),
-        ...(exists
-          ? {}
-          : {
-              hint: hasLatestElsewhere
-                ? "This shell resolves to a different session than your last recording. Try `genmedia gallery open latest`."
-                : "No assets have been recorded for this session yet — run a model first.",
-            }),
-      },
-      { view: "default" },
-    );
+    // `gallery info` is the explicit "give me everything" form. Bare
+    // `gallery` (routed here via `default: "info"`) defaults to the compact
+    // open hint when stdout is pretty/TTY.
+    const explicitInfo = process.argv.includes("info");
+
+    const url = exists
+      ? paths.index_url
+      : hasLatestElsewhere
+        ? rootIndexUrl()
+        : null;
+
+    const openHint =
+      url === null
+        ? null
+        : `${colors.bold(colors.cyan("→"))} ${colors.bold("Open:")} ${colors.cyan(url)}`;
+
+    if (isJsonOutput() || explicitInfo) {
+      output(
+        {
+          scope: "session",
+          session_id: ctx.id,
+          session_source: ctx.source,
+          agent: ctx.agent,
+          agent_host: ctx.agentHost,
+          path: paths.index_path,
+          url: paths.index_url,
+          exists,
+          recording_disabled: isGalleryDisabled(),
+          index_url: rootIndexUrl(),
+          ...(hasLatestElsewhere
+            ? {
+                latest: {
+                  session_id: last.session_id,
+                  agent: last.agent,
+                  updated_at: last.updated_at,
+                  hint: "Open it with `genmedia gallery open latest`.",
+                },
+              }
+            : {}),
+          ...(exists
+            ? {}
+            : {
+                hint: hasLatestElsewhere
+                  ? "This shell resolves to a different session than your last recording. Try `genmedia gallery open latest`."
+                  : "No assets have been recorded for this session yet — run a model first.",
+              }),
+        },
+        { view: "default" },
+      );
+      if (!isJsonOutput() && openHint !== null) {
+        const rule = colors.dim("─".repeat(60));
+        process.stdout.write(`\n${rule}\n${openHint}\n`);
+      }
+      return;
+    }
+
+    if (openHint === null) {
+      process.stdout.write(
+        `${colors.dim("No assets recorded yet — run `genmedia run` to generate something.")}\n`,
+      );
+      return;
+    }
+
+    process.stdout.write(`${openHint}\n`);
   },
 });

--- a/src/commands/gallery/list.ts
+++ b/src/commands/gallery/list.ts
@@ -1,0 +1,74 @@
+import { defineCommand } from "citty";
+import {
+  listSessions,
+  regenerateRootIndexHtml,
+  rootIndexUrl,
+} from "../../lib/gallery";
+import { error, isJsonOutput, output } from "../../lib/output";
+import { colors } from "../../lib/ui";
+
+export const DEFAULT_LIMIT = 50;
+
+export function parseLimit(raw: string | undefined): number | null {
+  if (raw === undefined || raw === "") return DEFAULT_LIMIT;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return null;
+  return n;
+}
+
+export default defineCommand({
+  meta: {
+    name: "list",
+    description: "List recorded gallery sessions (newest first)",
+  },
+  args: {
+    limit: {
+      type: "string",
+      description: `Max sessions to return (default: ${DEFAULT_LIMIT})`,
+    },
+  },
+  async run({ args }) {
+    // The URL we print at the end points at on-disk HTML — refresh it so
+    // a user clicking through gets the current CLI's template.
+    regenerateRootIndexHtml();
+
+    const limit = parseLimit(args.limit);
+    if (limit === null) {
+      error(`Invalid --limit value: ${args.limit}`, {
+        hint: "Pass a positive integer (e.g. --limit 20).",
+      });
+    }
+    const sessions = listSessions().slice(0, limit);
+
+    if (isJsonOutput()) {
+      output(
+        {
+          scope: "list",
+          sessions,
+          count: sessions.length,
+          index_url: rootIndexUrl(),
+        },
+        { view: "default" },
+      );
+      return;
+    }
+
+    if (sessions.length === 0) {
+      process.stdout.write(
+        `${colors.dim("No sessions yet. Run `genmedia run` to generate something.")}\n`,
+      );
+      return;
+    }
+    for (const s of sessions) {
+      const meta = [s.agent, s.agent_host]
+        .filter((v): v is string => Boolean(v))
+        .join(" · ");
+      process.stdout.write(
+        `${colors.bold(s.session_id)}  ${colors.dim(meta || "unknown agent")}  ` +
+          `${s.asset_count} asset${s.asset_count === 1 ? "" : "s"} / ${s.run_count} run${s.run_count === 1 ? "" : "s"}  ` +
+          `${colors.dim(new Date(s.updated_at).toLocaleString())}\n`,
+      );
+    }
+    process.stdout.write(`\n${colors.dim(`Index: ${rootIndexUrl()}`)}\n`);
+  },
+});

--- a/src/commands/gallery/list.ts
+++ b/src/commands/gallery/list.ts
@@ -16,6 +16,36 @@ export function parseLimit(raw: string | undefined): number | null {
   return n;
 }
 
+const KIND_PLURAL: Record<string, string> = {
+  image: "images",
+  video: "videos",
+  audio: "audio",
+  model: "3d",
+  other: "other",
+};
+const KIND_SINGLE: Record<string, string> = {
+  image: "image",
+  video: "video",
+  audio: "audio",
+  model: "3d",
+  other: "other",
+};
+
+export function formatKindBreakdown(
+  counts: Record<string, number> | undefined,
+): string {
+  if (!counts) return "";
+  const order = ["image", "video", "audio", "model", "other"];
+  const parts: string[] = [];
+  for (const k of order) {
+    const n = counts[k] ?? 0;
+    if (!n) continue;
+    const word = n === 1 ? (KIND_SINGLE[k] ?? k) : (KIND_PLURAL[k] ?? k);
+    parts.push(`${n} ${word}`);
+  }
+  return parts.join(", ");
+}
+
 export default defineCommand({
   meta: {
     name: "list",
@@ -60,11 +90,12 @@ export default defineCommand({
       return;
     }
     for (const s of sessions) {
-      const meta = [s.agent, s.agent_host]
-        .filter((v): v is string => Boolean(v))
-        .join(" · ");
+      const labelPart = s.label ? `  ${colors.bold(s.label)}` : "";
+      const agentPart = s.agent ? `  ${colors.dim(s.agent)}` : "";
+      const breakdown = formatKindBreakdown(s.kind_counts);
+      const breakdownPart = breakdown ? `  ${colors.dim(breakdown)}` : "";
       process.stdout.write(
-        `${colors.bold(s.session_id)}  ${colors.dim(meta || "unknown agent")}  ` +
+        `${colors.bold(s.session_id)}${labelPart}${agentPart}${breakdownPart}  ` +
           `${s.asset_count} asset${s.asset_count === 1 ? "" : "s"} / ${s.run_count} run${s.run_count === 1 ? "" : "s"}  ` +
           `${colors.dim(new Date(s.updated_at).toLocaleString())}\n`,
       );

--- a/src/commands/gallery/open.ts
+++ b/src/commands/gallery/open.ts
@@ -1,0 +1,113 @@
+import { existsSync } from "node:fs";
+import { defineCommand } from "citty";
+import {
+  regenerateRootIndexHtml,
+  regenerateSessionHtml,
+} from "../../lib/gallery";
+import { error, isPrettyOutput, output } from "../../lib/output";
+import { colors, symbols } from "../../lib/ui";
+import { openInBrowser, resolveTarget } from "./shared";
+
+export default defineCommand({
+  meta: {
+    name: "open",
+    description:
+      "Open the all-sessions index (default) or a specific session in the default browser",
+  },
+  args: {
+    target: {
+      type: "positional",
+      required: false,
+      description:
+        'Target: omit for the all-sessions index, or pass "current", "latest", or a specific <session_id>',
+    },
+    print: {
+      type: "boolean",
+      description:
+        "Resolve target and print path/url only — do not spawn the browser",
+    },
+  },
+  async run({ args }) {
+    // No-arg default is the all-sessions index — always has something useful
+    // to show (or an empty state) and lets users navigate from there. The
+    // "index" keyword still resolves to the same target for explicit callers.
+    const resolved = resolveTarget(args.target ?? "index");
+    if (resolved.kind === "error") {
+      error(resolved.message, {
+        hint: "Use `genmedia gallery list` to see recorded sessions.",
+      });
+    }
+
+    if (resolved.kind === "index") {
+      // Re-render with the current CLI's template/version before handing over
+      // the URL — protects against stale HTML left behind by an older CLI.
+      regenerateRootIndexHtml();
+      const exists = existsSync(resolved.path);
+      const opened =
+        !args.print && exists ? openInBrowser(resolved.url) : false;
+
+      if (!exists && !args.print && isPrettyOutput()) {
+        process.stderr.write(
+          `${colors.yellow(symbols.warning)} No sessions recorded yet — nothing to open.\n`,
+        );
+      }
+      output(
+        {
+          scope: "open",
+          target: "index",
+          path: resolved.path,
+          url: resolved.url,
+          exists,
+          opened,
+          ...(exists
+            ? {}
+            : {
+                hint: "Run `genmedia run` to generate something first.",
+              }),
+        },
+        { view: "default" },
+      );
+      return;
+    }
+
+    const { paths, session_id, source } = resolved;
+    // Best-effort: refresh the target's HTML against the current bundled
+    // template before existsSync / opening. No-op for sessions without a
+    // data.json (e.g. a freshly-resolved "current" with nothing recorded).
+    regenerateSessionHtml(session_id);
+    const exists = existsSync(paths.index_path);
+    const opened =
+      !args.print && exists ? openInBrowser(paths.index_url) : false;
+
+    if (!exists && !args.print && isPrettyOutput()) {
+      const hint =
+        source === "current"
+          ? "Try `genmedia gallery open latest` to reattach to your most-recent session."
+          : "Use `genmedia gallery list` to find a valid session id.";
+      process.stderr.write(
+        `${colors.yellow(symbols.warning)} No gallery to open for this session yet.\n  ${colors.dim(hint)}\n`,
+      );
+    }
+
+    output(
+      {
+        scope: "open",
+        target: source,
+        session_id,
+        path: paths.index_path,
+        url: paths.index_url,
+        exists,
+        opened,
+        ...(exists
+          ? {}
+          : {
+              hint:
+                source === "current"
+                  ? "Run a model first, or use `genmedia gallery open latest`."
+                  : "Session id has no recorded data. Use `genmedia gallery list`.",
+            }),
+      },
+      { view: "default" },
+    );
+  },
+});

--- a/src/commands/gallery/rename.ts
+++ b/src/commands/gallery/rename.ts
@@ -1,0 +1,91 @@
+import { defineCommand } from "citty";
+import {
+  galleryPaths,
+  LABEL_MAX_LENGTH,
+  renameSession,
+  resolveLatestSessionId,
+} from "../../lib/gallery";
+import { error, output } from "../../lib/output";
+import { getSessionContext } from "../../lib/session";
+
+export default defineCommand({
+  meta: {
+    name: "rename",
+    description:
+      "Set or clear a display label for a session. The on-disk id is unchanged.",
+  },
+  args: {
+    target: {
+      type: "positional",
+      required: false,
+      description:
+        'Target: "current" (default), "latest", or a specific <session_id>',
+    },
+    label: {
+      type: "string",
+      description: `Display label (max ${LABEL_MAX_LENGTH} chars)`,
+    },
+    clear: {
+      type: "boolean",
+      description: "Remove the label instead of setting one",
+    },
+  },
+  async run({ args }) {
+    const hasLabel = typeof args.label === "string" && args.label !== "";
+    if (!hasLabel && !args.clear) {
+      error("`gallery rename` requires either --label '<name>' or --clear.", {
+        examples: [
+          "genmedia gallery rename --label 'fluffy dog batch'",
+          "genmedia gallery rename latest --label 'demo run'",
+          "genmedia gallery rename <session_id> --clear",
+        ],
+      });
+    }
+    if (hasLabel && args.clear) {
+      error("Pass --label OR --clear, not both.");
+    }
+
+    const target = (args.target ?? "current").trim();
+    let sessionId: string;
+    let source: "current" | "latest" | "explicit";
+    if (target === "latest") {
+      const id = resolveLatestSessionId();
+      if (!id) {
+        error("No recorded sessions to rename.", {
+          hint: "Run `genmedia run` first.",
+        });
+      }
+      sessionId = id;
+      source = "latest";
+    } else if (target === "current" || target === "") {
+      sessionId = getSessionContext().id;
+      source = "current";
+    } else {
+      sessionId = target;
+      source = "explicit";
+    }
+
+    const desired = args.clear ? null : (args.label as string);
+    const result = renameSession(sessionId, desired);
+    if (!result.ok) {
+      const message =
+        result.reason === "not-found"
+          ? `Session not found: ${sessionId}`
+          : result.reason === "too-long"
+            ? `Label too long — max ${LABEL_MAX_LENGTH} chars.`
+            : "Failed to write the label.";
+      error(message, { session_id: sessionId });
+    }
+
+    output(
+      {
+        scope: "rename",
+        target: source,
+        session_id: sessionId,
+        label: result.label,
+        url: galleryPaths(sessionId).index_url,
+      },
+      { view: "default" },
+    );
+  },
+});

--- a/src/commands/gallery/shared.ts
+++ b/src/commands/gallery/shared.ts
@@ -1,0 +1,130 @@
+import { spawn } from "node:child_process";
+import {
+  type GalleryPaths,
+  galleryPaths,
+  readLastSession,
+  resolveLatestSessionId,
+  rootIndexPath,
+  rootIndexUrl,
+} from "../../lib/gallery";
+import { getSessionContext, type SessionContext } from "../../lib/session";
+
+// Cross-platform `open <url>` — zero deps. Detached + stdio:ignore so the
+// process doesn't block the CLI on exit.
+export function openInBrowser(url: string): boolean {
+  const cmd =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "cmd"
+        : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    const child = spawn(cmd, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export type ResolvedTargetKind = "session" | "index";
+
+export interface ResolvedSessionTarget {
+  kind: "session";
+  // "current" = the session this CLI invocation resolves to via session.ts.
+  // "latest" = the last-recorded session pointer / sessions/ scan.
+  // "explicit" = a session id passed directly on the command line.
+  source: "current" | "latest" | "explicit";
+  session_id: string;
+  paths: GalleryPaths;
+}
+
+export interface ResolvedIndexTarget {
+  kind: "index";
+  source: "index";
+  path: string;
+  url: string;
+}
+
+export type ResolvedTarget = ResolvedSessionTarget | ResolvedIndexTarget;
+
+export interface TargetResolveError {
+  kind: "error";
+  reason: "latest-empty";
+  message: string;
+}
+
+// Resolves the user-provided target ("current" | "latest" | "index" | <id>)
+// to a concrete path bundle. Returns a `kind: "error"` shape for cases that
+// must be surfaced to the user (e.g. `latest` requested but no session has
+// ever been recorded).
+export function resolveTarget(
+  rawTarget: string | undefined,
+  ctx: SessionContext = getSessionContext(),
+): ResolvedTarget | TargetResolveError {
+  const target = (rawTarget ?? "current").trim();
+
+  if (target === "index") {
+    return {
+      kind: "index",
+      source: "index",
+      path: rootIndexPath(),
+      url: rootIndexUrl(),
+    };
+  }
+
+  if (target === "current" || target === "") {
+    return {
+      kind: "session",
+      source: "current",
+      session_id: ctx.id,
+      paths: galleryPaths(ctx.id),
+    };
+  }
+
+  if (target === "latest") {
+    const id = resolveLatestSessionId();
+    if (!id) {
+      return {
+        kind: "error",
+        reason: "latest-empty",
+        message:
+          "No recorded sessions yet — run `genmedia run` to generate something first.",
+      };
+    }
+    return {
+      kind: "session",
+      source: "latest",
+      session_id: id,
+      paths: galleryPaths(id),
+    };
+  }
+
+  // Anything else is treated as an explicit session id. We don't validate
+  // the id exists here — callers report `exists: false` so an agent can
+  // distinguish "typo" from "empty".
+  return {
+    kind: "session",
+    source: "explicit",
+    session_id: target,
+    paths: galleryPaths(target),
+  };
+}
+
+export function lastSessionMeta(): {
+  session_id: string;
+  agent: string | null;
+  updated_at: number;
+} | null {
+  const last = readLastSession();
+  if (!last) return null;
+  return {
+    session_id: last.session_id,
+    agent: last.agent,
+    updated_at: last.updated_at,
+  };
+}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -12,6 +12,7 @@ import {
   parseDownloadFlag,
 } from "../lib/download";
 import { formatApiError } from "../lib/error-format";
+import { buildGalleryFiles, recordRun } from "../lib/gallery";
 import { classifyModality, type Modality } from "../lib/modality";
 import { error, isPrettyOutput, output } from "../lib/output";
 import { parseValue } from "../lib/parse-value";
@@ -228,18 +229,21 @@ export default defineCommand({
       });
 
       requestId = result.requestId;
+      const durationMs = Math.round(performance.now() - modelStart);
       track("model_run", {
         endpointId,
         mode: "subscribe",
         ok: true,
-        durationMs: Math.round(performance.now() - modelStart),
+        durationMs,
         ...trackingMode,
       });
       spinner?.succeed(`Run completed (${result.requestId})`);
 
+      const mediaRefs = extractMediaRefs(result.data);
+
       let downloaded: Awaited<ReturnType<typeof downloadMedia>> | undefined;
       if (download.mode === "on") {
-        const refs = extractMediaRefs(result.data);
+        const refs = mediaRefs;
         if (refs.length > 0) {
           const spinnerDl = prettyMode
             ? createSpinner(`Downloading ${refs.length} file(s)`)
@@ -268,6 +272,17 @@ export default defineCommand({
         }
       }
 
+      const galleryPaths = recordRun({
+        ts: Date.now(),
+        request_id: result.requestId,
+        endpoint_id: endpointId,
+        modality: routed?.modality ?? null,
+        prompt:
+          typeof input.prompt === "string" ? (input.prompt as string) : null,
+        duration_ms: durationMs,
+        files: buildGalleryFiles(mediaRefs, downloaded?.downloaded ?? []),
+      });
+
       output(
         {
           status: "completed",
@@ -278,6 +293,15 @@ export default defineCommand({
           ...(downloaded ? { downloaded_files: downloaded.downloaded } : {}),
           ...(downloaded && downloaded.failed.length > 0
             ? { download_failures: downloaded.failed }
+            : {}),
+          ...(galleryPaths
+            ? {
+                gallery: {
+                  session_id: galleryPaths.session_id,
+                  path: galleryPaths.index_path,
+                  url: galleryPaths.index_url,
+                },
+              }
             : {}),
           ...(logs.length > 0 ? { logs } : {}),
         },

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -6,6 +6,7 @@ import {
   extractMediaRefs,
   parseDownloadFlag,
 } from "../lib/download";
+import { buildGalleryFiles, recordRun } from "../lib/gallery";
 import { error, output } from "../lib/output";
 import { normalizeLogs } from "../lib/request-logs";
 
@@ -55,26 +56,47 @@ export default defineCommand({
     const wantResult = Boolean(args.result) || download.mode === "on";
     if (wantResult) {
       const result = await fal.queue.result(endpointId, { requestId });
+      const mediaRefs = extractMediaRefs(result.data);
       let downloaded: Awaited<ReturnType<typeof downloadMedia>> | undefined;
       if (download.mode === "on") {
-        const refs = extractMediaRefs(result.data);
         downloaded =
-          refs.length > 0
+          mediaRefs.length > 0
             ? await downloadMedia({
-                refs,
+                refs: mediaRefs,
                 template: download.template,
                 requestId,
               })
             : { downloaded: [], failed: [] };
       }
+
+      const galleryPaths = recordRun({
+        ts: Date.now(),
+        request_id: requestId,
+        endpoint_id: endpointId,
+        modality: null,
+        prompt: null,
+        duration_ms: null,
+        files: buildGalleryFiles(mediaRefs, downloaded?.downloaded ?? []),
+      });
+
       output(
         {
           status: "completed",
+          endpoint_id: endpointId,
           request_id: requestId,
           result: result.data,
           ...(downloaded ? { downloaded_files: downloaded.downloaded } : {}),
           ...(downloaded && downloaded.failed.length > 0
             ? { download_failures: downloaded.failed }
+            : {}),
+          ...(galleryPaths
+            ? {
+                gallery: {
+                  session_id: galleryPaths.session_id,
+                  path: galleryPaths.index_path,
+                  url: galleryPaths.index_url,
+                },
+              }
             : {}),
         },
         { view: "status", showLogs: Boolean(args.logs) },

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,9 +166,12 @@ async function startCli(): Promise<void> {
           usage: "genmedia gallery [subcommand] [target] [flags]",
           subcommands: {
             "(none)":
-              "Print current session info (path, url, exists). Never opens a browser, never deletes.",
+              "Bare `gallery` in pretty TTY prints a single `→ Open: <url>` hint. JSON / non-TTY prints the full info payload. Use `gallery info` or `--json` to force the full payload from a TTY.",
+            info: "genmedia gallery info — print the full info payload (session id, path, url, exists, latest pointer) regardless of TTY.",
             open: 'genmedia gallery open [<target>] [--print] — no target opens the all-sessions index. Targets: "current", "latest", or <session_id>. Pass --print to resolve path/url without launching the browser.',
             list: "genmedia gallery list [--limit <n>] — list recorded sessions, newest first. (default limit: 50)",
+            rename:
+              'genmedia gallery rename [<target>] --label "<name>" | --clear — set or remove a display label. Target = "current" (default) | "latest" | <session_id>. The on-disk session id is unchanged.',
             clear:
               'genmedia gallery clear [<target>] --yes — target = "current" (default) | "latest" | "all" | <session_id>. --yes is REQUIRED; no interactive prompt.',
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ const KNOWN_COMMANDS = new Set([
   "upload",
   "pricing",
   "docs",
+  "gallery",
   "version",
   "update",
 ]);
@@ -121,6 +122,10 @@ async function startCli(): Promise<void> {
             "--help":
               "Introspect the model and render its input schema as CLI help",
           },
+          output_fields: {
+            gallery:
+              "On success, a `{ session_id, path, url }` pointing at a per-session static HTML gallery aggregating every asset generated in this agent session. Disable via GENMEDIA_NO_GALLERY=1.",
+          },
         },
         upload: {
           description: "Upload a local file or URL to fal.ai CDN",
@@ -139,6 +144,10 @@ async function startCli(): Promise<void> {
             "--download":
               "Download media from the result (implies --result). Optional value is a path or template with {index}, {name}, {ext}, {request_id}",
           },
+          output_fields: {
+            gallery:
+              "When --result returns media, a `{ session_id, path, url }` pointing at the per-session static HTML gallery. Disable via GENMEDIA_NO_GALLERY=1.",
+          },
         },
         pricing: {
           description: "Get pricing information for a model",
@@ -150,6 +159,27 @@ async function startCli(): Promise<void> {
             "Search fal.ai documentation, guides, and API references",
           usage: "genmedia docs <query>",
           args: "<query>",
+        },
+        gallery: {
+          description:
+            "Show or manage per-session HTML galleries of generated assets (file:// URL, no server)",
+          usage: "genmedia gallery [subcommand] [target] [flags]",
+          subcommands: {
+            "(none)":
+              "Print current session info (path, url, exists). Never opens a browser, never deletes.",
+            open: 'genmedia gallery open [<target>] [--print] — no target opens the all-sessions index. Targets: "current", "latest", or <session_id>. Pass --print to resolve path/url without launching the browser.',
+            list: "genmedia gallery list [--limit <n>] — list recorded sessions, newest first. (default limit: 50)",
+            clear:
+              'genmedia gallery clear [<target>] --yes — target = "current" (default) | "latest" | "all" | <session_id>. --yes is REQUIRED; no interactive prompt.',
+          },
+          env: {
+            GENMEDIA_NO_GALLERY:
+              "Set to 1 to disable gallery recording. Reads (list/open/clear) still work so prior galleries remain inspectable.",
+            GENMEDIA_SESSION_ID:
+              "Force a specific session id (overrides agent / terminal detection)",
+            GENMEDIA_GALLERY_RETENTION_DAYS:
+              "Prune session directories older than N days (default: 60)",
+          },
         },
         version: {
           description: "Show version and check for updates",
@@ -260,6 +290,7 @@ async function startCli(): Promise<void> {
       upload: () => import("./commands/upload").then((m) => m.default),
       pricing: () => import("./commands/pricing").then((m) => m.default),
       docs: () => import("./commands/docs").then((m) => m.default),
+      gallery: () => import("./commands/gallery/index").then((m) => m.default),
       version: () => import("./commands/version").then((m) => m.default),
       update: () => import("./commands/update").then((m) => m.default),
     },

--- a/src/lib/gallery-assets/index.client.js
+++ b/src/lib/gallery-assets/index.client.js
@@ -13,6 +13,7 @@
     const assets = s.asset_count || 0;
     return {
       session_id: s.session_id,
+      label: s.label || null,
       agent: s.agent || null,
       agent_host: s.agent_host || null,
       started_at: s.started_at || 0,
@@ -21,6 +22,7 @@
       assets: assets,
       breakdown: kinds,
       modalities: s.modalities || [],
+      previews: Array.isArray(s.previews) ? s.previews : [],
       live: isLive(s.updated_at),
     };
   }
@@ -114,6 +116,7 @@
       arr = arr.filter(
         (s) =>
           s.session_id.toLowerCase().indexOf(q) !== -1 ||
+          (s.label && s.label.toLowerCase().indexOf(q) !== -1) ||
           (s.agent && s.agent.toLowerCase().indexOf(q) !== -1) ||
           (s.agent_host && s.agent_host.toLowerCase().indexOf(q) !== -1),
       );
@@ -176,12 +179,7 @@
       const t = order[j];
       if (!total[t]) continue;
       const c = (H.TYPE_INFO[t] || H.TYPE_INFO.other).color;
-      html +=
-        '<span class="b"><span class="sw" style="background:' +
-        c +
-        '"></span>' +
-        H.typeLabel(t, total[t]) +
-        "</span>";
+      html += `<span class="b" style="color:${c}" title="${H.escapeHtml(H.typeLabel(t, total[t]))}">${H.iconForKind(t, 12)}<span class="bn">${total[t]}</span></span>`;
     }
     root.innerHTML = html;
   }
@@ -191,12 +189,12 @@
     el.className = `session-card${s.live ? " live" : ""}`;
     el.href = `./sessions/${encodeURIComponent(s.session_id)}/index.html`;
 
-    const agent =
-      [s.agent, s.agent_host].filter(Boolean).join(" \u00B7 ") ||
-      "unknown agent";
+    const agentChip = s.agent
+      ? `<span class="chip">${H.escapeHtml(s.agent)}</span>`
+      : "";
 
     const segs = [];
-    const breakdownLabels = [];
+    const breakdownIcons = [];
     const entries = Object.keys(s.breakdown || {})
       .map((k) => [k, s.breakdown[k]])
       .filter((e) => e[1] > 0)
@@ -204,33 +202,60 @@
     for (let i = 0; i < entries.length; i++) {
       const k = entries[i][0];
       const n = entries[i][1];
-      const c = (H.TYPE_INFO[k] || H.TYPE_INFO.other).color;
-      segs.push(`<span style="background:${c}; flex:${n}"></span>`);
-      breakdownLabels.push(H.typeLabel(k, n));
+      const info = H.TYPE_INFO[k] || H.TYPE_INFO.other;
+      segs.push(`<span style="background:${info.color}; flex:${n}"></span>`);
+      breakdownIcons.push(
+        `<span class="bi" style="color:${info.color}" title="${H.escapeHtml(H.typeLabel(k, n))}">${H.iconForKind(k, 12)}<span class="bn">${n}</span></span>`,
+      );
     }
 
+    let thumbsHtml = "";
+    if (s.previews?.length) {
+      const items = [];
+      for (let i = 0; i < s.previews.length; i++) {
+        const p = s.previews[i];
+        const src = H.preferredSrc(p);
+        const safeSrc = H.escapeHtml(src);
+        let media;
+        if (p.kind === "video" && src) {
+          // First-frame trick: preload only metadata + seek to 0.1s so the
+          // browser paints a static poster without streaming the whole file.
+          media = `<video preload="metadata" muted playsinline src="${safeSrc}#t=0.1"></video><span class="play-badge"><span class="disc">${H.svgPlay(16)}</span></span>`;
+        } else if (p.kind === "audio") {
+          // Synthetic waveform — deterministic seed off the URL.
+          const bars = H.generateWaveform(p.url || p.file || "", 18, 0.55);
+          let barsHtml = "";
+          for (let b = 0; b < bars.length; b++) {
+            barsHtml += `<span class="bar" style="height:${Math.max(12, bars[b] * 100)}%"></span>`;
+          }
+          media = `<div class="audio-thumb">${barsHtml}</div><span class="play-badge"><span class="disc">${H.svgPlay(16)}</span></span>`;
+        } else if (p.kind === "image" && src) {
+          media = `<img src="${safeSrc}" alt="" loading="lazy" />`;
+        } else if (p.kind === "model" || p.kind === "other") {
+          // No meaningful media — render the kind icon as a faded placeholder.
+          const info = H.TYPE_INFO[p.kind] || H.TYPE_INFO.other;
+          media = `<div class="thumb-icon" style="color:${info.color}">${H.iconForKind(p.kind, 36)}</div>`;
+        } else {
+          // Unknown kind or missing src — skip.
+          continue;
+        }
+        items.push(`<span class="thumb">${media}</span>`);
+      }
+      if (items.length) {
+        thumbsHtml = `<div class="sc-thumbs">${items.join("")}</div>`;
+      }
+    }
+
+    const titleText = s.label || s.session_id;
+    const idClass = s.label ? "sc-id" : "sc-id mono";
+    const idTitleAttr = s.label ? ` title="${H.escapeHtml(s.session_id)}"` : "";
     el.innerHTML =
-      '<div class="sc-top">' +
-      '<span class="sc-id">' +
-      H.escapeHtml(s.session_id) +
-      "</span>" +
-      '<span class="chip">' +
-      H.escapeHtml(agent) +
-      "</span>" +
-      "</div>" +
+      `<div class="sc-top"><span class="${idClass}"${idTitleAttr}>${H.escapeHtml(titleText)}</span>${agentChip}</div>` +
+      thumbsHtml +
       '<p class="sc-summary">' +
-      "<strong>" +
-      s.assets +
-      "</strong> " +
-      (s.assets === 1 ? "asset" : "assets") +
-      " across <strong>" +
-      s.runs +
-      "</strong> " +
-      (s.runs === 1 ? "run" : "runs") +
-      (breakdownLabels.length
-        ? '<span class="sep">\u00B7</span><span class="breakdown">' +
-          H.escapeHtml(breakdownLabels.join(", ")) +
-          "</span>"
+      `<span class="sc-totals"><strong>${s.assets}</strong> ${s.assets === 1 ? "asset" : "assets"} across <strong>${s.runs}</strong> ${s.runs === 1 ? "run" : "runs"}</span>` +
+      (breakdownIcons.length
+        ? `<span class="breakdown-icons">${breakdownIcons.join("")}</span>`
         : "") +
       "</p>" +
       '<div class="sc-typebar">' +

--- a/src/lib/gallery-assets/index.client.js
+++ b/src/lib/gallery-assets/index.client.js
@@ -1,0 +1,258 @@
+/* genmedia gallery — sessions-index page controller. Reads a
+   { sessions: SessionSummary[] } payload from <script id="genmedia-data">. */
+
+(() => {
+  const H = window.__genmedia;
+  const DATA = H.readData() || { sessions: [] };
+  const SESSIONS = (DATA.sessions || []).map(adaptSession);
+
+  const state = { search: "", sort: "newest" };
+
+  function adaptSession(s) {
+    const kinds = s.kind_counts || {};
+    const assets = s.asset_count || 0;
+    return {
+      session_id: s.session_id,
+      agent: s.agent || null,
+      agent_host: s.agent_host || null,
+      started_at: s.started_at || 0,
+      updated_at: s.updated_at || 0,
+      runs: s.run_count || 0,
+      assets: assets,
+      breakdown: kinds,
+      modalities: s.modalities || [],
+      live: isLive(s.updated_at),
+    };
+  }
+
+  function isLive(ts) {
+    if (!ts) return false;
+    return Date.now() - ts < 5 * 60 * 1000;
+  }
+
+  function boot() {
+    renderHeaderChips();
+    bindToolbar();
+    bindKeyboard();
+    render();
+  }
+
+  function renderHeaderChips() {
+    const chips = document.getElementById("header-chips");
+    if (!chips) return;
+    const parts = [];
+    const liveCount = SESSIONS.filter((s) => s.live).length;
+    if (liveCount > 0) {
+      parts.push(
+        '<span class="chip"><span class="dot live"></span>' +
+          liveCount +
+          " live</span>",
+      );
+    }
+    const agents = uniq(SESSIONS.map((s) => s.agent).filter(Boolean));
+    if (agents.length) {
+      parts.push(
+        '<span class="chip">' +
+          agents.length +
+          " agent" +
+          (agents.length === 1 ? "" : "s") +
+          "</span>",
+      );
+    }
+    chips.innerHTML = parts.join("");
+  }
+
+  function uniq(arr) {
+    const seen = {};
+    const out = [];
+    for (let i = 0; i < arr.length; i++) {
+      if (!seen[arr[i]]) {
+        seen[arr[i]] = true;
+        out.push(arr[i]);
+      }
+    }
+    return out;
+  }
+
+  function bindToolbar() {
+    const search = document.getElementById("search-input");
+    if (search) {
+      search.addEventListener("input", (e) => {
+        state.search = e.target.value.trim();
+        render();
+      });
+    }
+    const sortSel = document.getElementById("sort-select");
+    if (sortSel) {
+      sortSel.addEventListener("change", (e) => {
+        state.sort = e.target.value;
+        render();
+      });
+    }
+  }
+
+  function bindKeyboard() {
+    document.addEventListener("keydown", (e) => {
+      const input = document.getElementById("search-input");
+      if (!input) return;
+      if (e.key === "/" && document.activeElement !== input) {
+        e.preventDefault();
+        input.focus();
+      } else if (e.key === "Escape" && document.activeElement === input) {
+        input.value = "";
+        state.search = "";
+        render();
+        input.blur();
+      }
+    });
+  }
+
+  function render() {
+    let arr = SESSIONS.slice();
+    if (state.search) {
+      const q = state.search.toLowerCase();
+      arr = arr.filter(
+        (s) =>
+          s.session_id.toLowerCase().indexOf(q) !== -1 ||
+          (s.agent && s.agent.toLowerCase().indexOf(q) !== -1) ||
+          (s.agent_host && s.agent_host.toLowerCase().indexOf(q) !== -1),
+      );
+    }
+    const cmp = {
+      newest: (a, b) => b.updated_at - a.updated_at,
+      oldest: (a, b) => a.updated_at - b.updated_at,
+      "assets-desc": (a, b) => b.assets - a.assets,
+      "runs-desc": (a, b) => b.runs - a.runs,
+    }[state.sort];
+    arr.sort(cmp);
+
+    const shown = document.getElementById("stat-shown");
+    const total = document.getElementById("stat-total");
+    if (shown) shown.textContent = String(arr.length);
+    if (total) total.textContent = String(SESSIONS.length);
+
+    renderTotalBreakdown();
+
+    const grid = document.getElementById("sessions-grid");
+    if (!grid) return;
+    grid.innerHTML = "";
+    if (!arr.length) {
+      const empty = document.createElement("div");
+      empty.className = "empty";
+      if (SESSIONS.length === 0) {
+        empty.innerHTML =
+          '<div class="em-title">No sessions yet</div>' +
+          '<div class="em-sub">Run <code>genmedia run …</code> to generate something.</div>';
+      } else {
+        empty.innerHTML =
+          '<div class="em-title">No matches</div>' +
+          '<div class="em-sub">"' +
+          H.escapeHtml(state.search) +
+          '"</div>';
+      }
+      grid.appendChild(empty);
+      return;
+    }
+    for (let i = 0; i < arr.length; i++) {
+      grid.appendChild(renderCard(arr[i]));
+    }
+  }
+
+  function renderTotalBreakdown() {
+    const root = document.getElementById("breakdown");
+    if (!root) return;
+    const total = {};
+    for (let i = 0; i < SESSIONS.length; i++) {
+      const b = SESSIONS[i].breakdown || {};
+      for (const k in b) {
+        if (Object.hasOwn(b, k)) {
+          total[k] = (total[k] || 0) + b[k];
+        }
+      }
+    }
+    const order = ["image", "video", "audio", "model", "other"];
+    let html = "";
+    for (let j = 0; j < order.length; j++) {
+      const t = order[j];
+      if (!total[t]) continue;
+      const c = (H.TYPE_INFO[t] || H.TYPE_INFO.other).color;
+      html +=
+        '<span class="b"><span class="sw" style="background:' +
+        c +
+        '"></span>' +
+        H.typeLabel(t, total[t]) +
+        "</span>";
+    }
+    root.innerHTML = html;
+  }
+
+  function renderCard(s) {
+    const el = document.createElement("a");
+    el.className = `session-card${s.live ? " live" : ""}`;
+    el.href = `./sessions/${encodeURIComponent(s.session_id)}/index.html`;
+
+    const agent =
+      [s.agent, s.agent_host].filter(Boolean).join(" \u00B7 ") ||
+      "unknown agent";
+
+    const segs = [];
+    const breakdownLabels = [];
+    const entries = Object.keys(s.breakdown || {})
+      .map((k) => [k, s.breakdown[k]])
+      .filter((e) => e[1] > 0)
+      .sort((a, b) => b[1] - a[1]);
+    for (let i = 0; i < entries.length; i++) {
+      const k = entries[i][0];
+      const n = entries[i][1];
+      const c = (H.TYPE_INFO[k] || H.TYPE_INFO.other).color;
+      segs.push(`<span style="background:${c}; flex:${n}"></span>`);
+      breakdownLabels.push(H.typeLabel(k, n));
+    }
+
+    el.innerHTML =
+      '<div class="sc-top">' +
+      '<span class="sc-id">' +
+      H.escapeHtml(s.session_id) +
+      "</span>" +
+      '<span class="chip">' +
+      H.escapeHtml(agent) +
+      "</span>" +
+      "</div>" +
+      '<p class="sc-summary">' +
+      "<strong>" +
+      s.assets +
+      "</strong> " +
+      (s.assets === 1 ? "asset" : "assets") +
+      " across <strong>" +
+      s.runs +
+      "</strong> " +
+      (s.runs === 1 ? "run" : "runs") +
+      (breakdownLabels.length
+        ? '<span class="sep">\u00B7</span><span class="breakdown">' +
+          H.escapeHtml(breakdownLabels.join(", ")) +
+          "</span>"
+        : "") +
+      "</p>" +
+      '<div class="sc-typebar">' +
+      segs.join("") +
+      "</div>" +
+      '<div class="sc-bottom">' +
+      "<span>" +
+      H.escapeHtml(H.formatRelative(s.updated_at)) +
+      "</span>" +
+      '<span class="right" title="' +
+      H.escapeHtml(H.formatTime(s.started_at)) +
+      '">since ' +
+      H.escapeHtml(H.formatRelative(s.started_at)) +
+      "</span>" +
+      "</div>";
+
+    return el;
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/src/lib/gallery-assets/index.css
+++ b/src/lib/gallery-assets/index.css
@@ -71,12 +71,91 @@
   justify-content: space-between;
   gap: 10px;
 }
+
+/* Fixed 25% slot width so sessions with <4 previews still pack left at a
+   consistent size — avoids one giant square for single-image sessions. */
+.sc-thumbs {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+}
+.sc-thumbs .thumb {
+  flex: 0 1 calc(25% - 3px);
+  aspect-ratio: 1;
+  background: var(--bg-overlay);
+  border-radius: var(--radius-2);
+  overflow: hidden;
+  display: block;
+  position: relative;
+}
+.sc-thumbs .thumb img,
+.sc-thumbs .thumb video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.sc-thumbs .thumb .thumb-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.55;
+}
+.sc-thumbs .thumb .audio-thumb {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 14% 8%;
+}
+.sc-thumbs .thumb .audio-thumb .bar {
+  flex: 1 1 0;
+  min-width: 0;
+  background: var(--fg-muted);
+  border-radius: 2px;
+  opacity: 0.55;
+}
+.sc-thumbs .thumb .play-badge {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.sc-thumbs .thumb .play-badge .disc {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  transition:
+    background 0.15s,
+    transform 0.15s;
+}
+.session-card:hover .sc-thumbs .thumb .play-badge .disc {
+  background: rgba(0, 0, 0, 0.65);
+  transform: scale(1.06);
+}
 .sc-id {
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
   font-size: 15px;
   font-weight: 600;
   color: var(--fg);
   letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sc-id.mono {
+  font-family: var(--font-mono);
 }
 
 .sc-summary {
@@ -84,6 +163,14 @@
   line-height: 1.45;
   color: var(--fg-muted);
   margin: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.sc-summary .sc-totals {
+  min-width: 0;
 }
 .sc-summary strong {
   color: var(--fg);
@@ -94,10 +181,24 @@
   color: var(--fg-faint);
   margin: 0 4px;
 }
-.sc-summary .breakdown {
-  color: var(--fg-subtle);
-  font-family: var(--font-mono);
+.sc-summary .breakdown-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  vertical-align: middle;
+  font-variant-numeric: tabular-nums;
+}
+.sc-summary .bi {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   font-size: 12px;
+}
+.sc-summary .bi svg {
+  display: block;
+}
+.sc-summary .bi .bn {
+  color: var(--fg-muted);
 }
 
 .sc-typebar {

--- a/src/lib/gallery-assets/index.css
+++ b/src/lib/gallery-assets/index.css
@@ -1,0 +1,145 @@
+/* =========================================================================
+   genmedia — sessions-index page specific styles
+   ========================================================================= */
+
+.sessions-toolbar {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding-bottom: 16px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--border-muted);
+}
+@media (max-width: 560px) {
+  .sessions-toolbar {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sessions-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--gap);
+}
+@media (max-width: 1200px) {
+  .sessions-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+@media (max-width: 880px) {
+  .sessions-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 560px) {
+  .sessions-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.session-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-4);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    transform 0.15s;
+  cursor: pointer;
+  position: relative;
+}
+.session-card:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-raised);
+}
+.session-card:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--accent-ring);
+}
+
+.sc-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.sc-id {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: 0;
+}
+
+.sc-summary {
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--fg-muted);
+  margin: 0;
+}
+.sc-summary strong {
+  color: var(--fg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.sc-summary .sep {
+  color: var(--fg-faint);
+  margin: 0 4px;
+}
+.sc-summary .breakdown {
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.sc-typebar {
+  display: flex;
+  height: 4px;
+  border-radius: var(--radius-round);
+  overflow: hidden;
+  background: var(--bg-overlay);
+  margin-top: 2px;
+}
+.sc-typebar > span {
+  height: 100%;
+  transition: opacity 0.15s;
+}
+.session-card:hover .sc-typebar > span {
+  opacity: 0.92;
+}
+
+.sc-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: auto;
+  padding-top: 8px;
+  font-size: 12px;
+  color: var(--fg-subtle);
+  border-top: 1px solid var(--border-muted);
+}
+.sc-bottom .right {
+  color: var(--fg-faint);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.session-card.live::after {
+  content: "";
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #00bc7d;
+  box-shadow: 0 0 0 3px rgba(0, 188, 125, 0.18);
+}

--- a/src/lib/gallery-assets/index.html.tmpl
+++ b/src/lib/gallery-assets/index.html.tmpl
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>genmedia sessions</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      {{{styles}}}
+    </style>
+  </head>
+  <body data-theme="black">
+    <div class="page">
+      <header class="header">
+        <div>
+          <div class="title-row">
+            {{{fal_icon}}}
+            <h1 class="session-title">genmedia sessions</h1>
+            <a class="powered-by" href="https://fal.ai" target="_blank" rel="noopener">powered by fal.ai</a>
+          </div>
+          <div class="meta-chips" id="header-chips"></div>
+        </div>
+        <div class="stats">
+          <div class="row">
+            <span>
+              <strong id="stat-shown">0</strong> of
+              <strong id="stat-total">0</strong> sessions
+            </span>
+          </div>
+          <div class="breakdown" id="breakdown"></div>
+        </div>
+      </header>
+
+      <div class="sessions-toolbar">
+        <div class="search">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            id="search-input"
+            type="text"
+            placeholder="Search session id / agent"
+            autocomplete="off"
+          />
+          <span class="kbd">/</span>
+        </div>
+        <div class="sort">
+          <select id="sort-select">
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="assets-desc">Most assets</option>
+            <option value="runs-desc">Most runs</option>
+          </select>
+          <svg
+            class="caret"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </div>
+      </div>
+
+      <main class="sessions-grid" id="sessions-grid"></main>
+
+      <footer class="page-footer">
+        <a href="https://genmedia.sh" target="_blank" rel="noopener">genmedia.sh</a>
+        <span class="sep">·</span>
+        <span class="mono version">v{{version}}</span>
+      </footer>
+    </div>
+
+    <script id="genmedia-data" type="application/json">{{{data}}}</script>
+    <script>
+      {{{shared_script}}}
+    </script>
+    <script>
+      {{{page_script}}}
+    </script>
+  </body>
+</html>

--- a/src/lib/gallery-assets/session.client.js
+++ b/src/lib/gallery-assets/session.client.js
@@ -1,0 +1,922 @@
+/* genmedia gallery — session page controller (vanilla JS).
+   Reads the SessionPayload from <script id="genmedia-data"> and renders
+   the filterable grid + lightbox + tweaks panel. */
+
+(() => {
+  const H = window.__genmedia;
+  let DATA = H.readData() || { runs: [] };
+
+  const FILTERS = ["all", "image", "video", "audio", "model", "other"];
+
+  const state = {
+    filter: "all",
+    search: "",
+    sort: "newest",
+    cols: 4,
+    density: "comfortable",
+    showActions: true,
+    theme: "black",
+    activeIdx: null,
+    activeAudio: null,
+  };
+
+  let ALL_ASSETS = flattenAssets(DATA);
+  let VIEW = [];
+
+  /* ---------- Adaptation: runs+files -> flat assets -------------------- */
+  function flattenAssets(data) {
+    const out = [];
+    const runs = data.runs || [];
+    for (let i = 0; i < runs.length; i++) {
+      const r = runs[i];
+      const files = r.files || [];
+      for (let j = 0; j < files.length; j++) {
+        const f = files[j];
+        const id = `${r.request_id || `r${i}`}:${f.json_path || `f${j}`}`;
+        out.push({
+          id: id,
+          type: f.kind || "other",
+          endpoint: r.endpoint_id || "",
+          request_id: r.request_id || "",
+          prompt: r.prompt || "",
+          timestamp: r.ts || 0,
+          run: i + 1,
+          path: f.json_path || "",
+          file: f.path || null,
+          size: f.size_bytes,
+          url: f.url || "",
+          modality: r.modality || null,
+          run_duration_ms: r.duration_ms,
+          format: inferFormat(f.path, f.url, f.kind),
+          waveform: f.kind === "audio" ? H.generateWaveform(id, 64, 0.5) : null,
+        });
+      }
+    }
+    return out;
+  }
+
+  function falRequestUrl(asset) {
+    if (!asset || !asset.endpoint || !asset.request_id) return "";
+    return `https://fal.ai/models/${asset.endpoint}/requests/${asset.request_id}`;
+  }
+
+  function inferFormat(path, url, kind) {
+    const s = path || url || "";
+    const m = /\.([a-z0-9]+)(?:[?#]|$)/i.exec(s);
+    if (m) return m[1].toLowerCase();
+    return kind === "model" ? "glb" : "";
+  }
+
+  /* ---------- Boot ----------------------------------------------------- */
+  function boot() {
+    renderHeaderChips();
+    renderFilters();
+    renderBreakdown();
+    bindToolbar();
+    bindLightbox();
+    bindTweaks();
+    bindKeyboard();
+    setupEditMode();
+    applyFilters();
+    if (isLive(DATA.updated_at)) startLivePolling();
+  }
+
+  /* ---------- Live polling --------------------------------------------- */
+  /* When the session is "live" (updated within the last 5 min), poll the
+     sidecar data.json so the user sees new runs land without reloading.
+     Static-file architecture is preserved — the page just re-fetches its
+     own data file via file:// and re-renders. */
+  function startLivePolling() {
+    const POLL_MS = 5000;
+    let intervalId = null;
+
+    function tick() {
+      // Skip while hidden or while the lightbox is open (active index would
+      // become stale if ALL_ASSETS changed underneath us).
+      if (document.hidden || state.activeIdx !== null) return;
+      // Live window closed — one final refresh of the header chips so the
+      // dot stops glowing, then stop polling.
+      if (!isLive(DATA.updated_at)) {
+        stopPolling();
+        renderHeaderChips();
+        return;
+      }
+      fetch("./data.json", { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((fresh) => {
+          if (!fresh || !Array.isArray(fresh.runs)) return;
+          const freshTs = fresh.updated_at || 0;
+          const curTs = DATA.updated_at || 0;
+          if (freshTs <= curTs && fresh.runs.length === DATA.runs.length) {
+            return;
+          }
+          DATA = fresh;
+          ALL_ASSETS = flattenAssets(DATA);
+          renderHeaderChips();
+          renderFilters();
+          renderBreakdown();
+          applyFilters();
+        })
+        .catch(() => {
+          // Network / parse errors are non-fatal — just try again next tick.
+        });
+    }
+
+    function stopPolling() {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      document.removeEventListener("visibilitychange", onVisibility);
+    }
+
+    function onVisibility() {
+      if (!document.hidden) tick();
+    }
+
+    intervalId = setInterval(tick, POLL_MS);
+    document.addEventListener("visibilitychange", onVisibility);
+  }
+
+  /* ---------- Header --------------------------------------------------- */
+  function renderHeaderChips() {
+    const chips = document.getElementById("header-chips");
+    if (!chips) return;
+    const parts = [];
+    if (DATA.session_id) {
+      parts.push(
+        `<span class="chip mono">${H.escapeHtml(DATA.session_id)}</span>`,
+      );
+    }
+    if (DATA.agent || DATA.agent_host) {
+      const agentLabel = [DATA.agent, DATA.agent_host]
+        .filter(Boolean)
+        .join(" \u00B7 ");
+      const live = isLive(DATA.updated_at);
+      parts.push(
+        '<span class="chip">' +
+          '<span class="dot' +
+          (live ? " live" : "") +
+          '"></span>' +
+          H.escapeHtml(agentLabel) +
+          "</span>",
+      );
+    }
+    const rangeLabel = formatRangeLabel(DATA);
+    if (rangeLabel) {
+      parts.push(`<span class="chip mono">${H.escapeHtml(rangeLabel)}</span>`);
+    }
+    chips.innerHTML = parts.join("");
+  }
+
+  function formatRangeLabel(data) {
+    if (!data.runs || !data.runs.length) return "no runs yet";
+    const first = new Date(data.started_at || data.updated_at || Date.now());
+    const n = data.runs.length;
+    return (
+      first.toLocaleDateString() +
+      " \u00B7 " +
+      n +
+      " run" +
+      (n === 1 ? "" : "s")
+    );
+  }
+
+  function isLive(ts) {
+    if (!ts) return false;
+    return Date.now() - ts < 5 * 60 * 1000;
+  }
+
+  /* ---------- Filters / search / sort --------------------------------- */
+  function countByType(arr) {
+    const r = {};
+    for (let i = 0; i < arr.length; i++)
+      r[arr[i].type] = (r[arr[i].type] || 0) + 1;
+    return r;
+  }
+
+  function renderFilters() {
+    const root = document.getElementById("filters");
+    if (!root) return;
+    const counts = countByType(ALL_ASSETS);
+    let html = "";
+    for (let i = 0; i < FILTERS.length; i++) {
+      const f = FILTERS[i];
+      const n = f === "all" ? ALL_ASSETS.length : counts[f] || 0;
+      html +=
+        '<button class="fc" data-filter="' +
+        f +
+        '" aria-pressed="' +
+        (state.filter === f ? "true" : "false") +
+        '"><span>' +
+        f +
+        '</span><span class="count">' +
+        n +
+        "</span></button>";
+    }
+    root.innerHTML = html;
+    root.querySelectorAll(".fc").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        state.filter = btn.dataset.filter;
+        root.querySelectorAll(".fc").forEach((b) => {
+          b.setAttribute(
+            "aria-pressed",
+            b.dataset.filter === state.filter ? "true" : "false",
+          );
+        });
+        applyFilters();
+      });
+    });
+  }
+
+  function renderBreakdown() {
+    const root = document.getElementById("breakdown");
+    if (!root) return;
+    const counts = countByType(ALL_ASSETS);
+    const order = ["image", "video", "audio", "model", "other"];
+    let html = "";
+    for (let i = 0; i < order.length; i++) {
+      const t = order[i];
+      if (!counts[t]) continue;
+      const c = (H.TYPE_INFO[t] || H.TYPE_INFO.other).color;
+      html +=
+        '<span class="b"><span class="sw" style="background:' +
+        c +
+        '"></span>' +
+        H.typeLabel(t, counts[t]) +
+        "</span>";
+    }
+    root.innerHTML = html;
+  }
+
+  function bindToolbar() {
+    const search = document.getElementById("search-input");
+    if (search) {
+      search.addEventListener("input", (e) => {
+        state.search = e.target.value.trim().toLowerCase();
+        applyFilters();
+      });
+    }
+    const sortSel = document.getElementById("sort-select");
+    if (sortSel) {
+      sortSel.addEventListener("change", (e) => {
+        state.sort = e.target.value;
+        applyFilters();
+      });
+    }
+  }
+
+  function applyFilters() {
+    let arr = ALL_ASSETS;
+    if (state.filter !== "all") {
+      arr = arr.filter((a) => a.type === state.filter);
+    }
+    if (state.search) {
+      const q = state.search;
+      arr = arr.filter(
+        (a) =>
+          (a.prompt && a.prompt.toLowerCase().indexOf(q) !== -1) ||
+          (a.endpoint && a.endpoint.toLowerCase().indexOf(q) !== -1) ||
+          (a.file && a.file.toLowerCase().indexOf(q) !== -1) ||
+          (a.path && a.path.toLowerCase().indexOf(q) !== -1),
+      );
+    }
+    const cmp = {
+      newest: (a, b) => b.timestamp - a.timestamp,
+      oldest: (a, b) => a.timestamp - b.timestamp,
+      "size-desc": (a, b) => (b.size || 0) - (a.size || 0),
+      "size-asc": (a, b) => (a.size || 0) - (b.size || 0),
+      endpoint: (a, b) => (a.endpoint || "").localeCompare(b.endpoint || ""),
+    }[state.sort];
+    arr = arr.slice().sort(cmp);
+    VIEW = arr;
+    const shown = document.getElementById("stat-shown");
+    const total = document.getElementById("stat-total");
+    if (shown) shown.textContent = String(arr.length);
+    if (total) total.textContent = String(ALL_ASSETS.length);
+    renderGrid();
+  }
+
+  /* ---------- Grid + card rendering ----------------------------------- */
+  function renderGrid() {
+    const grid = document.getElementById("grid");
+    if (!grid) return;
+    grid.style.setProperty("--cols", state.cols);
+    grid.innerHTML = "";
+
+    if (!VIEW.length) {
+      const empty = document.createElement("div");
+      empty.className = "empty";
+      empty.innerHTML =
+        '<div class="em-title">' +
+        (ALL_ASSETS.length === 0
+          ? "No assets generated in this session yet."
+          : "No matches.") +
+        "</div>" +
+        '<div class="em-sub">' +
+        (state.search
+          ? `query "${H.escapeHtml(state.search)}"`
+          : `filter: ${state.filter}`) +
+        "</div>";
+      grid.appendChild(empty);
+      return;
+    }
+    for (let i = 0; i < VIEW.length; i++) {
+      grid.appendChild(renderCard(VIEW[i], i));
+    }
+  }
+
+  function renderCard(asset, idx) {
+    const el = document.createElement("article");
+    el.className = "card";
+    el.tabIndex = 0;
+    el.dataset.id = asset.id;
+    el.dataset.type = asset.type;
+
+    const ti = H.TYPE_INFO[asset.type] || H.TYPE_INFO.other;
+
+    const preview = document.createElement("div");
+    preview.className = "preview";
+    const src = H.preferredSrc(asset);
+
+    const badge =
+      '<div class="type-badge"><span class="sw" style="background:' +
+      ti.color +
+      '"></span>' +
+      ti.label +
+      "</div>";
+
+    if (asset.type === "image" && src) {
+      preview.innerHTML = `<img src="${H.escapeHtml(src)}" alt="" loading="lazy" />${badge}`;
+    } else if (asset.type === "video" && src) {
+      preview.innerHTML =
+        '<video preload="metadata" muted playsinline src="' +
+        H.escapeHtml(src) +
+        '#t=0.1"></video>' +
+        badge +
+        '<div class="play-overlay"><div class="ring">' +
+        H.svgPlay(20) +
+        "</div></div>";
+    } else if (asset.type === "audio") {
+      preview.appendChild(renderAudioStage(asset));
+      const b = document.createElement("div");
+      b.className = "type-badge";
+      b.innerHTML =
+        '<span class="sw" style="background:' +
+        ti.color +
+        '"></span>' +
+        ti.label;
+      preview.appendChild(b);
+    } else if (asset.type === "model") {
+      preview.innerHTML =
+        '<div class="model-stage">' +
+        H.svgCube(92) +
+        (asset.format
+          ? `<div class="fmt">${H.escapeHtml(asset.format)}</div>`
+          : "") +
+        "</div>" +
+        badge;
+    } else {
+      preview.innerHTML =
+        '<div style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;color:var(--fg-faint);">' +
+        H.svgIconFile(40) +
+        "</div>" +
+        badge;
+    }
+
+    const body = document.createElement("div");
+    body.className = `body${state.density === "compact" ? " compact" : ""}`;
+    // Short request id for the meta-row. Cards stay scannable; the full id
+    // sits in title= for hover and is also shown in the lightbox.
+    const reqShort =
+      asset.request_id && asset.request_id.length > 10
+        ? `${asset.request_id.slice(0, 8)}\u2026`
+        : asset.request_id || "";
+    body.innerHTML =
+      '<div class="endpoint" title="' +
+      H.escapeHtml(asset.endpoint) +
+      '">' +
+      H.escapeHtml(asset.endpoint) +
+      "</div>" +
+      // Skip the prompt element entirely when empty \u2014 the placeholder line
+      // was eating vertical space without adding signal. Cards in the same
+      // grid row may have different heights now; that's acceptable.
+      (asset.prompt
+        ? `<p class="prompt">${H.escapeHtml(asset.prompt)}</p>`
+        : "") +
+      '<div class="meta-row">' +
+      '<span class="left">' +
+      `<span>${H.escapeHtml(H.formatRelative(asset.timestamp))}</span>` +
+      (reqShort
+        ? `<span class="sep">\u00B7</span><span class="req" title="${H.escapeHtml(asset.request_id)}">${H.escapeHtml(reqShort)}</span>`
+        : "") +
+      "</span>" +
+      '<span class="right">' +
+      `<span>${H.escapeHtml(asset.path)}</span>` +
+      (asset.size
+        ? `<span class="sep">\u00B7</span><span>${H.escapeHtml(H.formatBytes(asset.size))}</span>`
+        : "") +
+      "</span></div>";
+
+    const actions = document.createElement("div");
+    actions.className = "actions";
+    if (!state.showActions) actions.hidden = true;
+    let actHtml = "";
+    const falUrl = falRequestUrl(asset);
+    if (falUrl) {
+      actHtml +=
+        '<a class="action-btn" data-act="open-fal" href="' +
+        H.escapeHtml(falUrl) +
+        '" target="_blank" rel="noopener">' +
+        H.svgOpen() +
+        " View on fal.ai</a>";
+    }
+    if (asset.url) {
+      actHtml +=
+        '<button type="button" class="action-btn" data-act="copy-url">' +
+        H.svgCopy() +
+        " Copy URL</button>";
+      actHtml +=
+        '<a class="action-btn" data-act="open-original" href="' +
+        H.escapeHtml(asset.url) +
+        '" target="_blank" rel="noopener">' +
+        H.svgOpen() +
+        " Open original</a>";
+    }
+    if (asset.file) {
+      actHtml +=
+        '<a class="action-btn" data-act="open-file" href="' +
+        H.escapeHtml(H.preferredSrc(asset)) +
+        '" target="_blank" rel="noopener">' +
+        H.svgFile() +
+        " Open file</a>";
+    }
+    actions.innerHTML = actHtml;
+
+    el.append(preview, body, actions);
+
+    el.addEventListener("click", (e) => {
+      const btn = e.target.closest?.(".action-btn");
+      if (btn && btn.dataset.act === "copy-url") {
+        H.copyText(asset.url);
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      if (btn) {
+        e.stopPropagation();
+        return;
+      }
+      if (e.target.closest?.(".audio-stage .play-btn")) {
+        e.stopPropagation();
+        return;
+      }
+      openLightbox(idx);
+    });
+    el.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openLightbox(idx);
+      }
+    });
+
+    return el;
+  }
+
+  function renderAudioStage(asset) {
+    const wrap = document.createElement("div");
+    wrap.className = "audio-stage";
+    wrap.dataset.id = asset.id;
+    const endpointTail =
+      (asset.endpoint || "").split("/").slice(-1)[0] || "audio";
+
+    wrap.innerHTML =
+      '<div class="label">audio \u00B7 ' +
+      H.escapeHtml(endpointTail) +
+      "</div>" +
+      '<div class="wave"></div>' +
+      '<button class="play-btn" type="button" aria-label="Preview">' +
+      H.svgPlay(14) +
+      "</button>";
+
+    const wave = wrap.querySelector(".wave");
+    const bars = asset.waveform || H.generateWaveform(asset.id, 64, 0.5);
+    const barFrag = document.createDocumentFragment();
+    for (let i = 0; i < bars.length; i++) {
+      const bar = document.createElement("div");
+      bar.className = "bar";
+      bar.style.height = `${Math.max(8, bars[i] * 100)}%`;
+      barFrag.appendChild(bar);
+    }
+    wave.appendChild(barFrag);
+
+    const src = H.preferredSrc(asset);
+    const audio = document.createElement("audio");
+    audio.src = src;
+    audio.preload = "none";
+    audio.style.display = "none";
+    wrap.appendChild(audio);
+
+    wrap.addEventListener("mousemove", (e) => {
+      if (!audio.paused) return;
+      const rect = wave.getBoundingClientRect();
+      const r = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+      const allBars = wrap.querySelectorAll(".wave .bar");
+      allBars.forEach((b, idx2) => {
+        b.classList.toggle("played", idx2 / allBars.length <= r);
+      });
+    });
+    wrap.addEventListener("mouseleave", () => {
+      if (!audio.paused) return;
+      wrap.querySelectorAll(".wave .bar").forEach((b) => {
+        b.classList.remove("played");
+      });
+    });
+
+    wrap.querySelector(".play-btn").addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (audio.paused) {
+        if (state.activeAudio && state.activeAudio !== audio) {
+          state.activeAudio.pause();
+        }
+        state.activeAudio = audio;
+        audio.play();
+      } else {
+        audio.pause();
+      }
+    });
+
+    audio.addEventListener("timeupdate", () => {
+      const t = audio.duration ? audio.currentTime / audio.duration : 0;
+      const allBars = wrap.querySelectorAll(".wave .bar");
+      allBars.forEach((b, idx2) => {
+        b.classList.toggle("played", idx2 / allBars.length <= t);
+      });
+    });
+    audio.addEventListener("ended", () => {
+      const allBars = wrap.querySelectorAll(".wave .bar");
+      allBars.forEach((b) => {
+        b.classList.add("played");
+      });
+    });
+
+    return wrap;
+  }
+
+  /* ---------- Lightbox ------------------------------------------------- */
+  function bindLightbox() {
+    const lb = document.getElementById("lightbox");
+    if (!lb) return;
+    document
+      .getElementById("lb-close")
+      .addEventListener("click", closeLightbox);
+    document.getElementById("lb-prev").addEventListener("click", () => {
+      navLightbox(-1);
+    });
+    document.getElementById("lb-next").addEventListener("click", () => {
+      navLightbox(1);
+    });
+    lb.addEventListener("click", (e) => {
+      if (e.target === lb) closeLightbox();
+    });
+  }
+
+  function openLightbox(idx) {
+    state.activeIdx = idx;
+    renderLightbox();
+    document.getElementById("lightbox").setAttribute("data-open", "true");
+    document.body.style.overflow = "hidden";
+  }
+
+  function closeLightbox() {
+    const lb = document.getElementById("lightbox");
+    lb.setAttribute("data-open", "false");
+    document.body.style.overflow = "";
+    state.activeIdx = null;
+    if (state.activeAudio) {
+      state.activeAudio.pause();
+      state.activeAudio = null;
+    }
+    document.getElementById("lb-preview").innerHTML = "";
+  }
+
+  function navLightbox(dir) {
+    if (state.activeIdx == null) return;
+    let n = state.activeIdx + dir;
+    if (n < 0) n = VIEW.length - 1;
+    if (n >= VIEW.length) n = 0;
+    state.activeIdx = n;
+    renderLightbox();
+  }
+
+  function renderLightbox() {
+    const asset = VIEW[state.activeIdx];
+    if (!asset) return;
+    const preview = document.getElementById("lb-preview");
+    const meta = document.getElementById("lb-meta");
+    preview.innerHTML = "";
+    meta.innerHTML = "";
+
+    const src = H.preferredSrc(asset);
+
+    if (asset.type === "image" && src) {
+      preview.innerHTML =
+        '<img src="' +
+        H.escapeHtml(src) +
+        '" alt="' +
+        H.escapeHtml(asset.prompt) +
+        '" />';
+    } else if (asset.type === "video" && src) {
+      preview.innerHTML =
+        '<video controls autoplay playsinline src="' +
+        H.escapeHtml(src) +
+        '"></video>';
+    } else if (asset.type === "audio") {
+      const wfHtml = (asset.waveform || H.generateWaveform(asset.id, 96, 0.6))
+        .map(
+          (v) =>
+            '<div class="bar" style="height:' +
+            Math.max(10, v * 100) +
+            '%"></div>',
+        )
+        .join("");
+      const endpointTail =
+        (asset.endpoint || "").split("/").slice(-1)[0] || "audio";
+      preview.innerHTML =
+        '<div class="lb-audio">' +
+        '<div style="font-family:var(--font-mono);color:var(--fg-subtle);font-size:11px;letter-spacing:.05em;text-transform:uppercase;">audio waveform \u00B7 ' +
+        H.escapeHtml(endpointTail) +
+        "</div>" +
+        '<div class="lb-wave">' +
+        wfHtml +
+        "</div>" +
+        (src
+          ? '<audio controls preload="metadata" src="' +
+            H.escapeHtml(src) +
+            '"></audio>'
+          : "") +
+        "</div>";
+      const audio = preview.querySelector("audio");
+      const bars = preview.querySelectorAll(".lb-wave .bar");
+      if (audio) {
+        audio.addEventListener("timeupdate", () => {
+          const t = audio.duration ? audio.currentTime / audio.duration : 0;
+          bars.forEach((b, i) => {
+            b.classList.toggle("played", i / bars.length <= t);
+          });
+        });
+        audio.addEventListener("ended", () => {
+          bars.forEach((b) => {
+            b.classList.add("played");
+          });
+        });
+        state.activeAudio = audio;
+      }
+    } else if (asset.type === "model") {
+      preview.innerHTML =
+        '<div class="lb-model">' +
+        '<svg width="220" height="220" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<path d="M32 6 L56 18 L56 46 L32 58 L8 46 L8 18 Z"/>' +
+        '<path d="M32 6 L32 32 L56 18"/>' +
+        '<path d="M32 32 L32 58"/>' +
+        '<path d="M32 32 L8 18"/>' +
+        "</svg>" +
+        (asset.format
+          ? `<div class="fmt">${H.escapeHtml(asset.format)}</div>`
+          : "") +
+        "</div>";
+    } else {
+      preview.innerHTML =
+        '<div style="color:var(--fg-faint);display:flex;align-items:center;justify-content:center;width:100%;">' +
+        H.svgIconFile(80) +
+        "</div>";
+    }
+
+    let fields = "";
+    fields +=
+      '<div class="field"><span class="k">type</span><span class="v">' +
+      H.escapeHtml(asset.type) +
+      (asset.format ? ` \u00B7 ${H.escapeHtml(asset.format)}` : "") +
+      "</span></div>";
+    if (asset.size) {
+      fields +=
+        '<div class="field"><span class="k">size</span><span class="v">' +
+        H.escapeHtml(H.formatBytes(asset.size)) +
+        "</span></div>";
+    }
+    fields +=
+      '<div class="field"><span class="k">run</span><span class="v">#' +
+      asset.run +
+      "</span></div>";
+    if (asset.request_id) {
+      fields +=
+        '<div class="field"><span class="k">request id</span><span class="v">' +
+        H.escapeHtml(asset.request_id) +
+        "</span></div>";
+    }
+    fields +=
+      '<div class="field"><span class="k">timestamp</span><span class="v">' +
+      H.escapeHtml(H.formatTime(asset.timestamp)) +
+      "</span></div>";
+    if (asset.modality) {
+      fields +=
+        '<div class="field"><span class="k">modality</span><span class="v">' +
+        H.escapeHtml(asset.modality) +
+        "</span></div>";
+    }
+    if (asset.run_duration_ms) {
+      fields +=
+        '<div class="field"><span class="k">run latency</span><span class="v">' +
+        (asset.run_duration_ms / 1000).toFixed(2) +
+        "s</span></div>";
+    }
+    fields +=
+      '<div class="field"><span class="k">json path</span><span class="v">' +
+      H.escapeHtml(asset.path) +
+      "</span></div>";
+    if (asset.file) {
+      fields +=
+        '<div class="field"><span class="k">file</span><span class="v">' +
+        H.escapeHtml(asset.file) +
+        "</span></div>";
+    }
+    if (asset.url) {
+      fields +=
+        '<div class="field"><span class="k">url</span><span class="v">' +
+        H.escapeHtml(asset.url) +
+        "</span></div>";
+    }
+
+    let actions = "";
+    const falUrl = falRequestUrl(asset);
+    if (falUrl) {
+      actions +=
+        '<a class="primary" href="' +
+        H.escapeHtml(falUrl) +
+        '" target="_blank" rel="noopener">' +
+        H.svgOpen() +
+        " View on fal.ai</a>";
+    }
+    if (asset.url) {
+      actions +=
+        "<a" +
+        (falUrl ? "" : ' class="primary"') +
+        ' href="' +
+        H.escapeHtml(asset.url) +
+        '" target="_blank" rel="noopener">' +
+        H.svgOpen() +
+        " Open original</a>";
+      actions +=
+        '<button type="button" data-act="copy-url">' +
+        H.svgCopy() +
+        " Copy URL</button>";
+    }
+    if (asset.file) {
+      actions +=
+        '<a href="' +
+        H.escapeHtml(src) +
+        '" target="_blank" rel="noopener">' +
+        H.svgFile() +
+        " Open file</a>";
+    }
+    if (asset.prompt) {
+      actions +=
+        '<button type="button" data-act="copy-prompt">' +
+        H.svgCopy() +
+        " Copy prompt</button>";
+    }
+
+    meta.innerHTML =
+      '<div><h2>Endpoint</h2><div class="endpoint-big">' +
+      H.escapeHtml(asset.endpoint) +
+      "</div></div>" +
+      '<div><h2>Prompt</h2><p class="prompt-big' +
+      (asset.prompt ? "" : " empty") +
+      '">' +
+      (asset.prompt ? H.escapeHtml(asset.prompt) : "(no prompt)") +
+      "</p></div>" +
+      "<div><h2>Details</h2>" +
+      fields +
+      "</div>" +
+      '<div class="lb-actions">' +
+      actions +
+      "</div>";
+
+    meta.querySelectorAll("[data-act]").forEach((b) => {
+      b.addEventListener("click", () => {
+        const act = b.dataset.act;
+        if (act === "copy-url" && asset.url) H.copyText(asset.url);
+        else if (act === "copy-prompt" && asset.prompt)
+          H.copyText(asset.prompt);
+      });
+    });
+  }
+
+  /* ---------- Keyboard ------------------------------------------------- */
+  function bindKeyboard() {
+    document.addEventListener("keydown", (e) => {
+      const lb = document.getElementById("lightbox");
+      const lbOpen = lb && lb.getAttribute("data-open") === "true";
+      if (lbOpen) {
+        if (e.key === "Escape") closeLightbox();
+        else if (e.key === "ArrowLeft") navLightbox(-1);
+        else if (e.key === "ArrowRight") navLightbox(1);
+        return;
+      }
+      const search = document.getElementById("search-input");
+      if (e.key === "/" && document.activeElement !== search) {
+        e.preventDefault();
+        if (search) search.focus();
+      } else if (e.key === "Escape" && document.activeElement === search) {
+        search.value = "";
+        state.search = "";
+        applyFilters();
+        search.blur();
+      }
+    });
+  }
+
+  /* ---------- Tweaks panel -------------------------------------------- */
+  function bindTweaks() {
+    const btn = document.getElementById("tweaks-btn");
+    const panel = document.getElementById("tweaks");
+    const close = document.getElementById("tw-close");
+    if (!btn || !panel || !close) return;
+    btn.addEventListener("click", () => {
+      setTweaksOpen(true);
+    });
+    close.addEventListener("click", () => {
+      setTweaksOpen(false);
+    });
+
+    bindSeg("tw-cols", (v) => {
+      state.cols = parseInt(v, 10) || 4;
+      renderGrid();
+    });
+    bindSeg("tw-density", (v) => {
+      state.density = v;
+      renderGrid();
+    });
+    bindSeg("tw-theme", (v) => {
+      state.theme = v;
+      applyTheme();
+    });
+    const actionsToggle = document.getElementById("tw-actions");
+    if (actionsToggle) {
+      actionsToggle.addEventListener("change", (e) => {
+        state.showActions = e.target.checked;
+        renderGrid();
+      });
+    }
+  }
+
+  function bindSeg(rootId, onChange) {
+    const root = document.getElementById(rootId);
+    if (!root) return;
+    root.querySelectorAll("button").forEach((b) => {
+      b.addEventListener("click", () => {
+        root.querySelectorAll("button").forEach((x) => {
+          x.setAttribute("aria-pressed", x === b ? "true" : "false");
+        });
+        onChange(b.dataset.v);
+      });
+    });
+  }
+
+  function setTweaksOpen(open) {
+    const panel = document.getElementById("tweaks");
+    const btn = document.getElementById("tweaks-btn");
+    if (panel) panel.setAttribute("data-open", open ? "true" : "false");
+    if (btn) btn.hidden = open;
+    if (!open && window.parent !== window) {
+      window.parent.postMessage({ type: "__edit_mode_dismissed" }, "*");
+    }
+  }
+
+  function applyTheme() {
+    if (state.theme === "default") document.body.removeAttribute("data-theme");
+    else document.body.setAttribute("data-theme", state.theme);
+  }
+
+  /* Edit-mode protocol (host pages can toggle the tweaks panel via postMessage). */
+  function setupEditMode() {
+    window.addEventListener("message", (e) => {
+      const d = e.data;
+      if (!d || typeof d !== "object") return;
+      if (d.type === "__activate_edit_mode") setTweaksOpen(true);
+      else if (d.type === "__deactivate_edit_mode") setTweaksOpen(false);
+    });
+    if (window.parent !== window) {
+      window.parent.postMessage({ type: "__edit_mode_available" }, "*");
+    } else {
+      const btn = document.getElementById("tweaks-btn");
+      if (btn) btn.hidden = false;
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/src/lib/gallery-assets/session.client.js
+++ b/src/lib/gallery-assets/session.client.js
@@ -140,6 +140,11 @@
 
   /* ---------- Header --------------------------------------------------- */
   function renderHeaderChips() {
+    // Promote the user-set label into the page title when present.
+    const titleEl = document.querySelector(".session-title");
+    if (titleEl && DATA.label) titleEl.textContent = DATA.label;
+    if (DATA.label) document.title = DATA.label;
+
     const chips = document.getElementById("header-chips");
     if (!chips) return;
     const parts = [];
@@ -239,12 +244,7 @@
       const t = order[i];
       if (!counts[t]) continue;
       const c = (H.TYPE_INFO[t] || H.TYPE_INFO.other).color;
-      html +=
-        '<span class="b"><span class="sw" style="background:' +
-        c +
-        '"></span>' +
-        H.typeLabel(t, counts[t]) +
-        "</span>";
+      html += `<span class="b" style="color:${c}" title="${H.escapeHtml(H.typeLabel(t, counts[t]))}">${H.iconForKind(t, 12)}<span class="bn">${counts[t]}</span></span>`;
     }
     root.innerHTML = html;
   }

--- a/src/lib/gallery-assets/session.css
+++ b/src/lib/gallery-assets/session.css
@@ -1,0 +1,779 @@
+/* =========================================================================
+   genmedia — session page specific styles
+   ========================================================================= */
+
+/* ---------- Toolbar -------------------------------------------------- */
+.toolbar {
+  display: grid;
+  grid-template-columns: auto minmax(220px, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding-bottom: 16px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--border-muted);
+}
+@media (max-width: 880px) {
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+}
+
+.filter-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.fc {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: var(--radius-round);
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s,
+    border-color 0.12s;
+  font-family: inherit;
+}
+.fc:hover {
+  background: var(--bg-overlay);
+  color: var(--fg);
+}
+.fc[aria-pressed="true"] {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
+.fc .count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+}
+.fc[aria-pressed="true"] .count {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+/* ---------- Grid ----------------------------------------------------- */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(var(--cols), minmax(0, 1fr));
+  gap: var(--gap);
+}
+@media (max-width: 1200px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+@media (max-width: 880px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 560px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Card ----------------------------------------------------- */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-4);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    transform 0.15s,
+    background 0.15s;
+  position: relative;
+}
+.card:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-raised);
+}
+.card:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--accent-ring);
+}
+
+.preview {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  background: var(--bg-elev);
+  overflow: hidden;
+}
+.preview img,
+.preview video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.preview .type-badge {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  height: 22px;
+  padding: 0 8px 0 6px;
+  background: rgba(10, 10, 12, 0.78);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-round);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+}
+.preview .type-badge .sw {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+.preview .dur-badge {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  padding: 2px 7px;
+  background: rgba(10, 10, 12, 0.78);
+  backdrop-filter: blur(8px);
+  border-radius: var(--radius-2);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Video play overlay */
+.play-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+.play-overlay .ring {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+.card.playing .play-overlay {
+  opacity: 0;
+}
+
+/* Audio preview (no image) */
+.audio-stage {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--bg-elev) 0%, var(--bg-card) 100%);
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  justify-content: space-between;
+}
+.audio-stage .label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-subtle);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.audio-stage .wave {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 20px 0;
+}
+.audio-stage .wave .bar {
+  flex: 1;
+  background: var(--fg-faint);
+  border-radius: 1px;
+  transition: background 0.2s;
+}
+.audio-stage .wave .bar.played {
+  background: var(--audio-tint);
+}
+.audio-stage .play-btn {
+  align-self: flex-start;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--audio-tint);
+  color: #000;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.15s;
+}
+.audio-stage .play-btn:hover {
+  transform: scale(1.06);
+}
+
+/* 3D preview */
+.model-stage {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      60% 70% at 50% 45%,
+      rgba(173, 255, 0, 0.1) 0%,
+      rgba(173, 255, 0, 0) 70%
+    ),
+    var(--bg-elev);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--model-tint);
+}
+.model-stage svg.cube {
+  animation: spin 12s linear infinite;
+}
+.card:hover .model-stage svg.cube {
+  animation-duration: 4s;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.model-stage .fmt {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--model-tint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Card body */
+.body {
+  padding: 14px 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+.body.compact {
+  padding: 10px 14px 10px;
+  gap: 4px;
+}
+.endpoint {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-subtle);
+  letter-spacing: 0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.prompt {
+  font-size: 13.5px;
+  line-height: 1.42;
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin: 0;
+  text-wrap: pretty;
+}
+.meta-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  font-variant-numeric: tabular-nums;
+}
+.meta-row .left,
+.meta-row .right {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+.meta-row .right {
+  flex-shrink: 0;
+}
+.meta-row .req {
+  color: var(--fg-muted);
+  letter-spacing: 0.02em;
+}
+.meta-row .sep {
+  opacity: 0.5;
+}
+
+.actions {
+  display: flex;
+  gap: 14px;
+  padding: 10px 16px 14px;
+  border-top: 1px solid var(--border-muted);
+}
+.actions[hidden] {
+  display: none;
+}
+.action-btn {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--fg-subtle);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.12s;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  text-decoration: none;
+}
+.action-btn:hover {
+  color: var(--fg);
+}
+.action-btn svg {
+  opacity: 0.7;
+}
+.action-btn:hover svg {
+  opacity: 1;
+}
+
+/* ---------- Lightbox -------------------------------------------------- */
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(10px);
+  z-index: 100;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  animation: fadein 0.15s ease-out;
+}
+.lightbox[data-open="true"] {
+  display: flex;
+}
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.lb-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 24px;
+  width: 100%;
+  max-width: 1320px;
+  height: 100%;
+  max-height: 860px;
+}
+@media (max-width: 980px) {
+  .lb-stage {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
+}
+
+.lb-preview {
+  background: #000;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-5);
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.lb-preview img,
+.lb-preview video {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+.lb-preview .lb-audio {
+  width: 100%;
+  height: 100%;
+  padding: 60px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 32px;
+  background: linear-gradient(160deg, #0a0a0c, #1a1a1e);
+}
+.lb-preview .lb-audio .lb-wave {
+  display: flex;
+  gap: 3px;
+  align-items: center;
+  height: 200px;
+}
+.lb-preview .lb-audio .lb-wave .bar {
+  flex: 1;
+  background: var(--fg-faint);
+  border-radius: 2px;
+}
+.lb-preview .lb-audio .lb-wave .bar.played {
+  background: var(--audio-tint);
+}
+.lb-preview .lb-audio audio {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.lb-preview .lb-model {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    radial-gradient(
+      50% 60% at 50% 50%,
+      rgba(173, 255, 0, 0.15) 0%,
+      rgba(173, 255, 0, 0) 70%
+    ),
+    #0a0a0c;
+  color: var(--model-tint);
+}
+.lb-preview .lb-model svg {
+  animation: spin 8s linear infinite;
+}
+.lb-preview .lb-model .fmt {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--model-tint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lb-meta {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-5);
+  padding: 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.lb-close {
+  position: absolute;
+  top: 20px;
+  right: 24px;
+  width: 36px;
+  height: 36px;
+  background: rgba(20, 20, 24, 0.7);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(8px);
+  z-index: 2;
+}
+.lb-close:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+}
+
+.lb-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  background: rgba(20, 20, 24, 0.7);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(8px);
+  z-index: 2;
+}
+.lb-nav.prev {
+  left: 20px;
+}
+.lb-nav.next {
+  right: 20px;
+}
+.lb-nav:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+}
+
+.lb-meta h2 {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-subtle);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+}
+.lb-meta .endpoint-big {
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  color: var(--fg);
+  word-break: break-all;
+}
+.lb-meta .prompt-big {
+  font-size: 15.5px;
+  line-height: 1.5;
+  color: var(--fg);
+  margin: 0;
+  text-wrap: pretty;
+}
+.lb-meta .prompt-big.empty {
+  color: var(--fg-faint);
+  font-style: italic;
+}
+.lb-meta .field {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 12px;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-muted);
+  font-size: 12.5px;
+}
+.lb-meta .field:last-child {
+  border-bottom: none;
+}
+.lb-meta .field .k {
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+.lb-meta .field .v {
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  word-break: break-all;
+}
+
+.lb-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-top: 8px;
+}
+.lb-actions button,
+.lb-actions a {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-overlay);
+  color: var(--fg);
+  border-radius: var(--radius-2);
+  padding: 8px 14px;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+}
+.lb-actions button:hover,
+.lb-actions a:hover {
+  background: var(--bg-elev);
+  border-color: var(--border-strong);
+}
+.lb-actions .primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.lb-actions .primary:hover {
+  background: #762ff8;
+}
+
+/* ---------- Tweaks panel --------------------------------------------- */
+.tweaks-btn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  transition:
+    color 0.12s,
+    border-color 0.12s;
+}
+.tweaks-btn:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+}
+.tweaks-btn[hidden] {
+  display: none;
+}
+
+.tweaks {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 280px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-5);
+  padding: 16px;
+  z-index: 60;
+  display: none;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+}
+.tweaks[data-open="true"] {
+  display: flex;
+}
+.tweaks .tw-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+}
+.tweaks .tw-close {
+  background: transparent;
+  border: none;
+  color: var(--fg-subtle);
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+}
+.tweaks .tw-close:hover {
+  color: var(--fg);
+}
+.tweaks .tw-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.tweaks .tw-label {
+  font-size: 11px;
+  color: var(--fg-subtle);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.tweaks .tw-seg {
+  display: flex;
+  gap: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2);
+  padding: 2px;
+}
+.tweaks .tw-seg button {
+  flex: 1;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--fg-subtle);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px 0;
+  cursor: pointer;
+  border-radius: 3px;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+.tweaks .tw-seg button:hover {
+  color: var(--fg);
+}
+.tweaks .tw-seg button[aria-pressed="true"] {
+  background: var(--bg-overlay);
+  color: var(--fg);
+}
+.tweaks .tw-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+.tweaks .tw-toggle input {
+  accent-color: var(--accent);
+}
+.tweaks .tw-swatches {
+  display: flex;
+  gap: 8px;
+}
+.tweaks .tw-swatch {
+  flex: 1;
+  height: 32px;
+  border-radius: var(--radius-2);
+  cursor: pointer;
+  border: 1px solid var(--border);
+  transition:
+    border-color 0.12s,
+    transform 0.12s;
+}
+.tweaks .tw-swatch[aria-pressed="true"] {
+  border-color: var(--fg);
+}
+.tweaks .tw-swatch:hover {
+  transform: translateY(-1px);
+}

--- a/src/lib/gallery-assets/session.html.tmpl
+++ b/src/lib/gallery-assets/session.html.tmpl
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      {{{styles}}}
+    </style>
+  </head>
+  <body data-theme="black">
+    <div class="page">
+      <header class="header">
+        <div>
+          <div class="title-row">
+            {{{fal_icon}}}
+            <h1 class="session-title">genmedia session</h1>
+            <a class="powered-by" href="https://fal.ai" target="_blank" rel="noopener">powered by fal.ai</a>
+          </div>
+          <div class="meta-chips" id="header-chips"></div>
+        </div>
+        <div class="stats">
+          <div class="row">
+            <span>
+              <strong id="stat-shown">0</strong> of
+              <strong id="stat-total">0</strong> assets
+            </span>
+          </div>
+          <div class="breakdown" id="breakdown"></div>
+        </div>
+      </header>
+
+      <div class="toolbar">
+        <div class="filter-chips" id="filters"></div>
+
+        <div class="search">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            id="search-input"
+            type="text"
+            placeholder="Search prompts / endpoints / files"
+            autocomplete="off"
+          />
+          <span class="kbd">/</span>
+        </div>
+
+        <div class="sort">
+          <select id="sort-select">
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="size-desc">Largest first</option>
+            <option value="size-asc">Smallest first</option>
+            <option value="endpoint">By endpoint</option>
+          </select>
+          <svg
+            class="caret"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </div>
+      </div>
+
+      <main class="grid" id="grid"></main>
+
+      <footer class="page-footer">
+        <a href="https://genmedia.sh" target="_blank" rel="noopener">genmedia.sh</a>
+        <span class="sep">·</span>
+        <span class="mono version">v{{version}}</span>
+      </footer>
+    </div>
+
+    <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Asset detail">
+      <button class="lb-close" id="lb-close" aria-label="Close">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M18 6 6 18M6 6l12 12" />
+        </svg>
+      </button>
+      <button class="lb-nav prev" id="lb-prev" aria-label="Previous">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m15 18-6-6 6-6" />
+        </svg>
+      </button>
+      <button class="lb-nav next" id="lb-next" aria-label="Next">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </button>
+
+      <div class="lb-stage">
+        <div class="lb-preview" id="lb-preview"></div>
+        <aside class="lb-meta" id="lb-meta"></aside>
+      </div>
+    </div>
+
+    <button class="tweaks-btn" id="tweaks-btn" aria-label="Tweaks" hidden>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path
+          d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6"
+        />
+      </svg>
+    </button>
+
+    <div class="tweaks" id="tweaks" role="dialog" aria-label="Tweaks">
+      <div class="tw-header">
+        <span>Tweaks</span>
+        <button class="tw-close" id="tw-close" aria-label="Close">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="tw-row">
+        <span class="tw-label">Columns</span>
+        <div class="tw-seg" id="tw-cols">
+          <button data-v="3">3</button>
+          <button data-v="4" aria-pressed="true">4</button>
+          <button data-v="5">5</button>
+        </div>
+      </div>
+
+      <div class="tw-row">
+        <span class="tw-label">Theme</span>
+        <div class="tw-swatches" id="tw-theme">
+          <button class="tw-swatch" data-v="black" aria-pressed="true" style="background:#000;border-color:#222;"></button>
+          <button class="tw-swatch" data-v="default" style="background:#0a0a0c;border-color:#222;"></button>
+          <button class="tw-swatch" data-v="fal" style="background:#121216;border-color:#27272a;"></button>
+          <button class="tw-swatch" data-v="paper" style="background:#f7f7f5;"></button>
+        </div>
+      </div>
+
+      <div class="tw-row">
+        <span class="tw-label">Card density</span>
+        <div class="tw-seg" id="tw-density">
+          <button data-v="comfortable" aria-pressed="true">Comfortable</button>
+          <button data-v="compact">Compact</button>
+        </div>
+      </div>
+
+      <div class="tw-row">
+        <label class="tw-toggle">
+          <span>Show file actions</span>
+          <input type="checkbox" id="tw-actions" checked />
+        </label>
+      </div>
+    </div>
+
+    <script id="genmedia-data" type="application/json">{{{data}}}</script>
+    <script>
+      {{{shared_script}}}
+    </script>
+    <script>
+      {{{page_script}}}
+    </script>
+  </body>
+</html>

--- a/src/lib/gallery-assets/shared.client.js
+++ b/src/lib/gallery-assets/shared.client.js
@@ -1,0 +1,219 @@
+/* genmedia gallery — shared client helpers
+   Loaded by both the session and the sessions-index pages, before the
+   page-specific script. Exposes utilities on window.__genmedia. */
+
+(() => {
+  window.__genmedia ??= {};
+  const H = window.__genmedia;
+
+  H.readData = () => {
+    const node = document.getElementById("genmedia-data");
+    if (!node) return null;
+    try {
+      return JSON.parse(node.textContent);
+    } catch (_e) {
+      return null;
+    }
+  };
+
+  H.escapeHtml = (value) => {
+    if (value === null || value === undefined) return "";
+    return String(value).replace(
+      /[&<>"']/g,
+      (c) =>
+        ({
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          '"': "&quot;",
+          "'": "&#39;",
+        })[c],
+    );
+  };
+
+  H.formatBytes = (bytes) => {
+    if (bytes === null || bytes === undefined) return "";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 * 1024 * 1024)
+      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  };
+
+  H.formatRelative = (ts) => {
+    if (!ts) return "";
+    const diff = Date.now() - ts;
+    if (diff < 60000) return `${Math.max(1, Math.round(diff / 1000))}s ago`;
+    if (diff < 60 * 60000) return `${Math.round(diff / 60000)}m ago`;
+    if (diff < 24 * 60 * 60000)
+      return `${Math.round(diff / (60 * 60000))}h ago`;
+    return `${Math.round(diff / (24 * 60 * 60000))}d ago`;
+  };
+
+  H.formatTime = (ts) => {
+    if (!ts) return "";
+    return new Date(ts).toLocaleString();
+  };
+
+  H.formatDuration = (seconds) => {
+    if (seconds == null || !Number.isFinite(seconds)) return "";
+    const s = Math.max(0, seconds);
+    const m = Math.floor(s / 60);
+    const sec = Math.floor(s % 60);
+    return `${m}:${sec < 10 ? "0" : ""}${sec}`;
+  };
+
+  /* Deterministic pseudo-random waveform synth so each audio asset has
+     a stable-looking shape across renders. */
+  H.generateWaveform = (seed, n, energy) => {
+    const key = String(seed || "");
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < key.length; i++) {
+      h = (h ^ key.charCodeAt(i)) >>> 0;
+      h = Math.imul(h, 16777619) >>> 0;
+    }
+    const rng = () => {
+      h = (Math.imul(h, 1664525) + 1013904223) >>> 0;
+      return h / 0xffffffff;
+    };
+    const out = [];
+    const e = energy == null ? 0.5 : energy;
+    for (let j = 0; j < n; j++) {
+      const env = Math.sin((j / n) * Math.PI) * 0.7 + 0.3;
+      const noise = 0.4 + rng() * 0.6;
+      out.push(Math.min(1, env * noise * (0.5 + e)));
+    }
+    return out;
+  };
+
+  H.copyText = (text) => {
+    if (navigator.clipboard?.writeText) {
+      return navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          H.showToast("Copied");
+        })
+        .catch(() => {
+          fallbackCopy(text);
+        });
+    }
+    fallbackCopy(text);
+    return Promise.resolve();
+  };
+
+  function fallbackCopy(text) {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      document.execCommand("copy");
+      H.showToast("Copied");
+    } catch (_e) {
+      /* ignore */
+    }
+    document.body.removeChild(ta);
+  }
+
+  let toastTimer = null;
+  H.showToast = (text) => {
+    let el = document.querySelector(".toast");
+    if (!el) {
+      el = document.createElement("div");
+      el.className = "toast";
+      el.innerHTML =
+        '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>' +
+        '<span class="toast-text"></span>';
+      document.body.appendChild(el);
+    }
+    const t = el.querySelector(".toast-text") || el;
+    t.textContent = text;
+    el.classList.add("show");
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      el.classList.remove("show");
+    }, 1800);
+  };
+
+  /* Prefer the locally-downloaded file as a file:// URL so the gallery
+     works offline; fall back to the remote URL when no local copy exists. */
+  H.preferredSrc = (asset) => {
+    if (asset?.file) {
+      const parts = String(asset.file).split("/").map(encodeURIComponent);
+      return `file://${parts.join("/")}`;
+    }
+    return asset?.url ? asset.url : "";
+  };
+
+  /* ---------- Type metadata ------------------------------------------- */
+  H.TYPE_INFO = {
+    image: { label: "image", color: "#a1a1aa" },
+    video: { label: "video", color: "#a855f7" },
+    audio: { label: "audio", color: "#14cbf3" },
+    model: { label: "3d", color: "#adff00" },
+    other: { label: "other", color: "#787881" },
+  };
+
+  H.typeLabel = (kind, n) => {
+    const plural = {
+      image: "images",
+      video: "videos",
+      audio: "audio",
+      model: "3d",
+      other: "other",
+    };
+    const single = {
+      image: "image",
+      video: "video",
+      audio: "audio",
+      model: "3d",
+      other: "other",
+    };
+    return `${n} ${n === 1 ? single[kind] || kind : plural[kind] || kind}`;
+  };
+
+  /* ---------- Inline SVG icons ---------------------------------------- */
+  H.svgPlay = (s) => {
+    s = s || 16;
+    return (
+      '<svg width="' +
+      s +
+      '" height="' +
+      s +
+      '" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>'
+    );
+  };
+  H.svgCopy = () =>
+    '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+  H.svgOpen = () =>
+    '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="m10 14 11-11"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>';
+  H.svgFile = () =>
+    '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>';
+  H.svgIconFile = (s) => {
+    s = s || 40;
+    return (
+      '<svg width="' +
+      s +
+      '" height="' +
+      s +
+      '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>'
+    );
+  };
+  H.svgCube = (s) => {
+    s = s || 92;
+    return (
+      '<svg class="cube" width="' +
+      s +
+      '" height="' +
+      s +
+      '" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">' +
+      '<path d="M32 6 L56 18 L56 46 L32 58 L8 46 L8 18 Z"/>' +
+      '<path d="M32 6 L32 32 L56 18"/>' +
+      '<path d="M32 32 L32 58"/>' +
+      '<path d="M32 32 L8 18"/>' +
+      "</svg>"
+    );
+  };
+})();

--- a/src/lib/gallery-assets/shared.client.js
+++ b/src/lib/gallery-assets/shared.client.js
@@ -191,6 +191,25 @@
     '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="m10 14 11-11"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>';
   H.svgFile = () =>
     '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>';
+  H.svgImage = (s) => {
+    s = s || 13;
+    return `<svg width="${s}" height="${s}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>`;
+  };
+  H.svgVideo = (s) => {
+    s = s || 13;
+    return `<svg width="${s}" height="${s}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="14" height="12" rx="2"/><path d="m22 8-6 4 6 4z"/></svg>`;
+  };
+  H.svgAudio = (s) => {
+    s = s || 13;
+    return `<svg width="${s}" height="${s}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>`;
+  };
+  H.iconForKind = (kind, size) => {
+    if (kind === "image") return H.svgImage(size);
+    if (kind === "video") return H.svgVideo(size);
+    if (kind === "audio") return H.svgAudio(size);
+    if (kind === "model") return H.svgCube(size || 14);
+    return H.svgIconFile(size);
+  };
   H.svgIconFile = (s) => {
     s = s || 40;
     return (

--- a/src/lib/gallery-assets/styles.css
+++ b/src/lib/gallery-assets/styles.css
@@ -254,12 +254,14 @@ body {
 .stats .breakdown .b {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
 }
-.stats .breakdown .sw {
-  width: 7px;
-  height: 7px;
-  border-radius: 2px;
+.stats .breakdown .b svg {
+  display: block;
+}
+.stats .breakdown .b .bn {
+  color: var(--fg-muted);
+  font-size: 12px;
 }
 
 /* ---------- Scrollbar ---------------------------------------------------- */

--- a/src/lib/gallery-assets/styles.css
+++ b/src/lib/gallery-assets/styles.css
@@ -1,0 +1,415 @@
+/* =========================================================================
+   genmedia — shared base styles
+   Tokens, themes, body, page shell, header, chips, stats, scrollbar.
+   Page-specific CSS is concatenated separately in gallery-template.ts.
+   ========================================================================= */
+
+:root {
+  --bg: #0a0a0c;
+  --bg-raised: #131316;
+  --bg-card: #111114;
+  --bg-elev: #1a1a1e;
+  --bg-input: #161619;
+  --bg-overlay: rgba(255, 255, 255, 0.04);
+
+  --fg: #ffffff;
+  --fg-muted: #d4d4d8;
+  --fg-subtle: #787881;
+  --fg-faint: #494950;
+  --fg-placeholder: #5e5e66;
+
+  --border: rgba(255, 255, 255, 0.07);
+  --border-strong: rgba(255, 255, 255, 0.14);
+  --border-muted: rgba(255, 255, 255, 0.04);
+
+  --accent: #7f22fe;
+  --accent-soft: rgba(127, 34, 254, 0.16);
+  --accent-ring: 0 0 0 3px rgba(127, 34, 254, 0.28);
+
+  --img-tint: #1f2937;
+  --video-tint: #a855f7;
+  --audio-tint: #14cbf3;
+  --model-tint: #adff00;
+
+  --font-sans:
+    "Public Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+    sans-serif;
+  --font-mono:
+    "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --radius-2: 4px;
+  --radius-3: 6px;
+  --radius-4: 8px;
+  --radius-5: 12px;
+  --radius-round: 9999px;
+
+  --cols: 4;
+  --gap: 20px;
+}
+
+[data-theme="black"] {
+  --bg: #000000;
+  --bg-raised: #0b0b0d;
+  --bg-card: #0c0c0f;
+  --bg-elev: #16161a;
+  --bg-input: #101013;
+  --border: rgba(255, 255, 255, 0.06);
+}
+[data-theme="fal"] {
+  --bg: #121216;
+  --bg-raised: #1a1a1d;
+  --bg-card: #17171a;
+  --bg-elev: #202024;
+  --bg-input: #1b1b1f;
+}
+[data-theme="paper"] {
+  --bg: #f7f7f5;
+  --bg-raised: #ffffff;
+  --bg-card: #ffffff;
+  --bg-elev: #ffffff;
+  --bg-input: #ffffff;
+  --fg: #202022;
+  --fg-muted: #3f3f46;
+  --fg-subtle: #71717a;
+  --fg-faint: #a1a1aa;
+  --fg-placeholder: #a1a1aa;
+  --border: rgba(18, 18, 22, 0.08);
+  --border-strong: rgba(18, 18, 22, 0.16);
+  --border-muted: rgba(18, 18, 22, 0.04);
+  --bg-overlay: rgba(18, 18, 22, 0.04);
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family: var(--font-sans);
+  font-feature-settings: "ss01", "cv11";
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-feature-settings: "ss01", "ss02";
+}
+
+/* ---------- Page shell --------------------------------------------------- */
+.page {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 36px 40px 80px;
+}
+
+/* ---------- Header title row (icon + title + powered-by) ---------------- */
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  min-width: 0;
+}
+.fal-mark-icon {
+  display: block;
+  width: 18px;
+  height: 18px;
+  color: var(--fg);
+  flex-shrink: 0;
+}
+.powered-by {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--fg-faint);
+  text-decoration: none;
+  padding-left: 10px;
+  margin-left: 2px;
+  border-left: 1px solid var(--border-muted);
+  transition: color 0.15s;
+  white-space: nowrap;
+}
+.powered-by:hover {
+  color: var(--fg-subtle);
+}
+
+/* ---------- Page footer ------------------------------------------------- */
+.page-footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border-muted);
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+.page-footer a {
+  color: var(--fg-subtle);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.15s;
+}
+.page-footer a:hover {
+  color: var(--fg);
+}
+.page-footer .sep {
+  color: var(--fg-faint);
+  opacity: 0.6;
+}
+.page-footer .version {
+  font-size: 11px;
+  color: var(--fg-faint);
+}
+
+/* ---------- Header ------------------------------------------------------- */
+.header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 32px;
+  margin-bottom: 28px;
+}
+.session-title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--fg);
+}
+.meta-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: var(--radius-round);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-muted);
+  color: var(--fg-muted);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.chip.mono {
+  font-size: 11.5px;
+  padding: 0 9px;
+  font-family: var(--font-mono);
+}
+.chip .dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--fg-faint);
+}
+.chip .dot.live {
+  background: #00bc7d;
+  box-shadow: 0 0 0 3px rgba(0, 188, 125, 0.18);
+}
+
+.stats {
+  text-align: right;
+  color: var(--fg-subtle);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.stats .row {
+  display: flex;
+  gap: 16px;
+  justify-content: flex-end;
+  align-items: baseline;
+}
+.stats strong {
+  color: var(--fg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.stats .breakdown {
+  margin-top: 4px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+}
+.stats .breakdown .b {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.stats .breakdown .sw {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+
+/* ---------- Scrollbar ---------------------------------------------------- */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--bg-overlay);
+  border-radius: var(--radius-round);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-strong);
+}
+
+/* ---------- Generic empty state ----------------------------------------- */
+.empty {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 20px;
+  color: var(--fg-subtle);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-4);
+  background: var(--bg-card);
+}
+.empty .em-title {
+  font-size: 14px;
+  color: var(--fg-muted);
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+.empty .em-sub {
+  font-size: 12.5px;
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+}
+
+/* ---------- Toolbar building blocks (used on both pages) ---------------- */
+.search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.search svg {
+  position: absolute;
+  left: 12px;
+  color: var(--fg-faint);
+  pointer-events: none;
+}
+.search input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px 0 36px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-round);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 13px;
+  outline: none;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.search input::placeholder {
+  color: var(--fg-placeholder);
+}
+.search input:focus {
+  border-color: var(--border-strong);
+  box-shadow: var(--accent-ring);
+}
+.search .kbd {
+  position: absolute;
+  right: 10px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-faint);
+  background: var(--bg-overlay);
+  padding: 2px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--border-muted);
+  pointer-events: none;
+}
+.search input:not(:placeholder-shown) ~ .kbd {
+  display: none;
+}
+
+.sort {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.sort select {
+  appearance: none;
+  height: 36px;
+  padding: 0 32px 0 14px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-round);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+}
+.sort select:focus {
+  border-color: var(--border-strong);
+  box-shadow: var(--accent-ring);
+}
+.sort .caret {
+  position: absolute;
+  right: 12px;
+  pointer-events: none;
+  color: var(--fg-subtle);
+}
+
+/* ---------- Toast (created on demand by shared.client.js) -------------- */
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: var(--fg);
+  color: var(--bg);
+  padding: 10px 16px;
+  border-radius: var(--radius-round);
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  z-index: 200;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.2s,
+    transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+.toast svg {
+  color: #00bc7d;
+}

--- a/src/lib/gallery-template.ts
+++ b/src/lib/gallery-template.ts
@@ -66,11 +66,23 @@ export interface SessionPayload {
   cwd: string | null;
   started_at: number;
   updated_at: number;
+  // Optional user-set display name. Cosmetic only — the on-disk id stays
+  // anchored to the process-tree resolver so future runs still land here.
+  label?: string;
   runs: RunRecord[];
+}
+
+// image/video render real media; audio = synthetic waveform; 3d/other =
+// kind-icon placeholder. All counted toward the 4-slot cap (FIFO).
+export interface SessionPreview {
+  kind: "image" | "video" | "audio" | "model" | "other";
+  file: string | null;
+  url: string;
 }
 
 export interface SessionSummary {
   session_id: string;
+  label: string | null;
   agent: string | null;
   agent_host: string | null;
   started_at: number;
@@ -79,6 +91,7 @@ export interface SessionSummary {
   asset_count: number;
   kind_counts: Record<AssetKind, number>;
   modalities: string[];
+  previews: SessionPreview[];
 }
 
 const HTML_ESCAPE_RE = /[&<>"']/g;

--- a/src/lib/gallery-template.ts
+++ b/src/lib/gallery-template.ts
@@ -1,0 +1,151 @@
+// Pure HTML renderer for the genmedia gallery. NO I/O at request time, no
+// `process`/`fs` access. The actual HTML / CSS / JS lives in
+// `./gallery-assets/` as editable .html / .css / .js files; we just splice
+// page-specific data into a Mustache-style template at call time.
+//
+// Bun embeds the files as string constants via `with { type: "text" }`, so
+// the compiled binary still ships a single self-contained executable.
+
+// The HTML templates intentionally use the `.html.tmpl` extension: Bun's
+// build pipeline applies its HTML loader to any `*.html` file in the
+// import graph and strips `{{{...}}}` braces inside `<script>` blocks
+// (parsing them as broken JS) even with `with { type: "text" }`. A
+// non-`.html` extension keeps Bun's HTML loader out of the way so the
+// templater can see the raw placeholders.
+import indexScript from "./gallery-assets/index.client.js" with {
+  type: "text",
+};
+import indexCss from "./gallery-assets/index.css" with { type: "text" };
+import indexHtml from "./gallery-assets/index.html.tmpl" with { type: "text" };
+import sessionScript from "./gallery-assets/session.client.js" with {
+  type: "text",
+};
+import sessionCss from "./gallery-assets/session.css" with { type: "text" };
+import sessionHtml from "./gallery-assets/session.html.tmpl" with {
+  type: "text",
+};
+import sharedScript from "./gallery-assets/shared.client.js" with {
+  type: "text",
+};
+import sharedStyles from "./gallery-assets/styles.css" with { type: "text" };
+import { VERSION } from "./version";
+
+// fal.ai brand icon (the leaf/asterisk mark only — extracted from the
+// full wordmark in apps/web/src/components/base/logo.tsx). Color is
+// inherited from the surrounding text via `currentColor`. We pair this
+// with a separate "powered by fal.ai" link in the title row, so the
+// brand chrome shrinks down to one tight line.
+const FAL_ICON = `<svg class="fal-mark-icon" viewBox="0 0 47 48" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M30.1574 0.740479C30.9676 0.740479 31.6169 1.39923 31.6944 2.20567C32.3853 9.39891 38.1102 15.1234 45.3039 15.8142C46.1104 15.8917 46.7692 16.541 46.7692 17.3511V30.8959C46.7692 31.706 46.1104 32.3553 45.3039 32.4328C38.1102 33.1236 32.3853 38.8481 31.6944 46.0414C31.6169 46.8478 30.9676 47.5065 30.1574 47.5065H16.6118C15.8016 47.5065 15.1523 46.8478 15.0748 46.0414C14.384 38.8481 8.65901 33.1236 1.46528 32.4328C0.658799 32.3553 0 31.706 0 30.8959V17.3511C0 16.541 0.658803 15.8917 1.46529 15.8142C8.65902 15.1234 14.384 9.39891 15.0748 2.20567C15.1523 1.39923 15.8016 0.740479 16.6118 0.740479H30.1574ZM9.39037 24.0839C9.39037 31.865 15.6915 38.1728 23.4644 38.1728C31.2373 38.1728 37.5385 31.865 37.5385 24.0839C37.5385 16.3028 31.2373 9.99498 23.4644 9.99498C15.6915 9.99498 9.39037 16.3028 9.39037 24.0839Z"/></svg>`;
+
+export type AssetKind = "image" | "video" | "audio" | "model" | "other";
+
+export interface GalleryFile {
+  path: string | null;
+  url: string;
+  size_bytes: number | null;
+  kind: AssetKind;
+  json_path: string;
+}
+
+export interface RunRecord {
+  ts: number;
+  request_id: string;
+  endpoint_id: string;
+  modality: string | null;
+  prompt: string | null;
+  duration_ms: number | null;
+  files: GalleryFile[];
+}
+
+export interface SessionPayload {
+  schema_version: 1;
+  session_id: string;
+  session_source: string;
+  agent: string | null;
+  agent_host: string | null;
+  cwd: string | null;
+  started_at: number;
+  updated_at: number;
+  runs: RunRecord[];
+}
+
+export interface SessionSummary {
+  session_id: string;
+  agent: string | null;
+  agent_host: string | null;
+  started_at: number;
+  updated_at: number;
+  run_count: number;
+  asset_count: number;
+  kind_counts: Record<AssetKind, number>;
+  modalities: string[];
+}
+
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(HTML_ESCAPE_RE, (c) => HTML_ESCAPE_MAP[c] ?? c);
+}
+
+// Escapes a JSON string so it can be embedded inside <script>...</script>
+// without breaking out of the tag. `</script>` is the only sequence that
+// matters; `<!--` is escaped for good measure.
+function safeJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll("</", "<\\/")
+    .replaceAll("<!--", "<\\u0021--");
+}
+
+// Tiny Mustache-style templater. Two forms only:
+//   - `{{key}}`   — HTML-escaped substitution
+//   - `{{{key}}}` — raw substitution
+// Unknown keys are removed (so leftover placeholders never reach the user).
+// Substitution is a single pass — inserted strings are never re-scanned, so
+// values that happen to contain `{{…}}` make it through verbatim.
+const TEMPLATE_RE = /\{\{\{\s*(\w+)\s*\}\}\}|\{\{\s*(\w+)\s*\}\}/g;
+
+export function applyTemplate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(
+    TEMPLATE_RE,
+    (_match, rawKey: string | undefined, escKey: string | undefined) => {
+      if (rawKey !== undefined) {
+        return Object.hasOwn(vars, rawKey) ? vars[rawKey] : "";
+      }
+      const key = escKey as string;
+      return Object.hasOwn(vars, key) ? escapeHtml(vars[key]) : "";
+    },
+  );
+}
+
+export function renderSessionHtml(payload: SessionPayload): string {
+  return applyTemplate(sessionHtml, {
+    title: `genmedia session ${payload.session_id}`,
+    styles: `${sharedStyles}\n${sessionCss}`,
+    shared_script: sharedScript,
+    page_script: sessionScript,
+    data: safeJson(payload),
+    version: VERSION,
+    fal_icon: FAL_ICON,
+  });
+}
+
+export function renderSessionsIndexHtml(sessions: SessionSummary[]): string {
+  return applyTemplate(indexHtml, {
+    styles: `${sharedStyles}\n${indexCss}`,
+    shared_script: sharedScript,
+    page_script: indexScript,
+    data: safeJson({ schema_version: 1 as const, sessions }),
+    version: VERSION,
+    fal_icon: FAL_ICON,
+  });
+}

--- a/src/lib/gallery.test.ts
+++ b/src/lib/gallery.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test";
+import { buildGalleryFiles, kindFor } from "./gallery";
+import {
+  applyTemplate,
+  renderSessionHtml,
+  renderSessionsIndexHtml,
+} from "./gallery-template";
+
+describe("kindFor", () => {
+  test("matches by file extension on a local path", () => {
+    expect(kindFor({ path: "/tmp/foo.png" })).toBe("image");
+    expect(kindFor({ path: "/tmp/foo.MP4" })).toBe("video");
+    expect(kindFor({ path: "/tmp/clip.webm" })).toBe("video");
+    expect(kindFor({ path: "/tmp/sound.wav" })).toBe("audio");
+    expect(kindFor({ path: "/tmp/asset.glb" })).toBe("model");
+  });
+
+  test("matches by file extension in a URL", () => {
+    expect(kindFor({ url: "https://cdn.example.com/path/cat.jpg" })).toBe(
+      "image",
+    );
+    expect(kindFor({ url: "https://cdn.example.com/clip.mp4?token=abc" })).toBe(
+      "video",
+    );
+  });
+
+  test("falls back to MIME prefix when extension is unknown", () => {
+    expect(
+      kindFor({
+        url: "https://cdn.example.com/x",
+        contentType: "image/webp",
+      }),
+    ).toBe("image");
+    expect(kindFor({ contentType: "audio/mpeg; charset=utf-8" })).toBe("audio");
+  });
+
+  test("returns 'other' when nothing matches", () => {
+    expect(kindFor({})).toBe("other");
+    expect(kindFor({ url: "https://example.com/page", contentType: "" })).toBe(
+      "other",
+    );
+    expect(
+      kindFor({ url: "not-a-real-url://", contentType: "text/html" }),
+    ).toBe("other");
+  });
+
+  test("local path beats URL hint", () => {
+    expect(
+      kindFor({
+        path: "/tmp/foo.mp3",
+        url: "https://cdn.example.com/foo.png",
+      }),
+    ).toBe("audio");
+  });
+});
+
+describe("buildGalleryFiles", () => {
+  test("pairs downloaded local paths to their source refs by json_path", () => {
+    const refs = [
+      {
+        url: "https://cdn.example.com/a.png",
+        contentType: "image/png",
+        jsonPath: "images[0]",
+        fileSize: 100,
+      },
+      {
+        url: "https://cdn.example.com/b.png",
+        contentType: "image/png",
+        jsonPath: "images[1]",
+      },
+    ];
+    const downloaded = [
+      {
+        url: "https://cdn.example.com/a.png",
+        path: "/out/a.png",
+        size_bytes: 99,
+        json_path: "images[0]",
+      },
+    ];
+    const out = buildGalleryFiles(refs, downloaded);
+    expect(out).toHaveLength(2);
+    expect(out[0].path).toBe("/out/a.png");
+    expect(out[0].kind).toBe("image");
+    expect(out[0].size_bytes).toBe(99);
+    expect(out[1].path).toBe(null);
+    expect(out[1].size_bytes).toBe(null);
+  });
+
+  test("falls back to URL matching when json_paths drift", () => {
+    const refs = [
+      {
+        url: "https://cdn.example.com/a.mp4",
+        contentType: "video/mp4",
+        jsonPath: "video",
+      },
+    ];
+    const downloaded = [
+      {
+        url: "https://cdn.example.com/a.mp4",
+        path: "/out/a.mp4",
+        size_bytes: 42,
+        json_path: "different",
+      },
+    ];
+    const out = buildGalleryFiles(refs, downloaded);
+    expect(out[0].path).toBe("/out/a.mp4");
+    expect(out[0].kind).toBe("video");
+  });
+
+  test("works with no downloads (URL-only galleries)", () => {
+    const refs = [
+      {
+        url: "https://cdn.example.com/a.png",
+        contentType: "image/png",
+        jsonPath: "images[0]",
+      },
+    ];
+    const out = buildGalleryFiles(refs);
+    expect(out).toHaveLength(1);
+    expect(out[0].path).toBe(null);
+    expect(out[0].url).toBe("https://cdn.example.com/a.png");
+    expect(out[0].kind).toBe("image");
+  });
+});
+
+describe("applyTemplate", () => {
+  test("HTML-escapes {{name}} substitutions", () => {
+    expect(applyTemplate("hi {{x}}", { x: "<b>x</b>" })).toBe(
+      "hi &lt;b&gt;x&lt;/b&gt;",
+    );
+    expect(applyTemplate("{{a}} & {{b}}", { a: '"a"', b: "'b'" })).toBe(
+      "&quot;a&quot; & &#39;b&#39;",
+    );
+  });
+
+  test("{{{name}}} substitutions are raw", () => {
+    expect(applyTemplate("<x>{{{html}}}</x>", { html: "<b>ok</b>" })).toBe(
+      "<x><b>ok</b></x>",
+    );
+  });
+
+  test("removes unknown placeholders so leftovers never reach the user", () => {
+    expect(applyTemplate("a {{missing}} b {{{also_missing}}} c", {})).toBe(
+      "a  b  c",
+    );
+  });
+
+  test("does not recurse — replacements containing placeholders stay literal", () => {
+    expect(
+      applyTemplate("{{{a}}}", { a: "{{x}}", x: "should-not-expand" }),
+    ).toBe("{{x}}");
+  });
+
+  test("tolerates whitespace inside the braces", () => {
+    expect(
+      applyTemplate("{{  name  }}-{{{ raw }}}", { name: "n", raw: "<r>" }),
+    ).toBe("n-<r>");
+  });
+});
+
+describe("renderSessionHtml / renderSessionsIndexHtml", () => {
+  test("session page embeds payload as JSON and references shared CSS classes", () => {
+    const html = renderSessionHtml({
+      schema_version: 1,
+      session_id: "abc123",
+      session_source: "override",
+      agent: "codex",
+      agent_host: null,
+      cwd: null,
+      started_at: 0,
+      updated_at: 0,
+      runs: [
+        {
+          ts: 0,
+          request_id: "r1",
+          endpoint_id: "fal-ai/flux/dev",
+          modality: "text-to-image",
+          prompt: "a cat",
+          duration_ms: 1000,
+          files: [
+            {
+              path: null,
+              url: "https://cdn.example.com/a.png",
+              size_bytes: null,
+              kind: "image",
+              json_path: "images[0]",
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toStartWith("<!doctype html>");
+    expect(html).toContain('id="genmedia-data"');
+    expect(html).toContain('"session_id":"abc123"');
+    expect(html).toContain('class="grid"');
+    expect(html).toContain("genmedia session abc123");
+    // New design surface: page shell + lightbox + tweaks panel scaffolding.
+    expect(html).toContain('class="page"');
+    expect(html).toContain('id="lightbox"');
+    expect(html).toContain('id="tweaks"');
+    expect(html).toContain('id="header-chips"');
+    // Shared + page-specific CSS were both inlined.
+    expect(html).toContain("--font-mono");
+    expect(html).toContain(".audio-stage");
+    // No unsubstituted placeholders made it to the output.
+    expect(html).not.toContain("{{");
+    expect(html).not.toContain("}}");
+  });
+
+  test("</script> sequences in the payload are escaped so they can't break out", () => {
+    const html = renderSessionHtml({
+      schema_version: 1,
+      session_id: "x",
+      session_source: "fallback",
+      agent: null,
+      agent_host: null,
+      cwd: null,
+      started_at: 0,
+      updated_at: 0,
+      runs: [
+        {
+          ts: 0,
+          request_id: "r",
+          endpoint_id: "e",
+          modality: null,
+          prompt: "</script><script>alert(1)</script>",
+          duration_ms: null,
+          files: [
+            {
+              path: null,
+              url: "https://x/a.png",
+              size_bytes: null,
+              kind: "image",
+              json_path: "",
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).not.toContain("</script><script>alert(1)");
+    expect(html).toContain("<\\/script>");
+  });
+
+  test("index page renders empty when there are no sessions", () => {
+    const html = renderSessionsIndexHtml([]);
+    expect(html).toContain("genmedia sessions");
+    expect(html).toContain('"sessions":[]');
+    expect(html).toContain('id="sessions-grid"');
+    expect(html).toContain(".session-card");
+    expect(html).not.toContain("{{");
+  });
+});

--- a/src/lib/gallery.ts
+++ b/src/lib/gallery.ts
@@ -55,6 +55,8 @@ function lastSessionPath(): string {
 const DATA_FILE = "data.json";
 const PAGE_FILE = "index.html";
 const MAX_RUNS_PER_SESSION = 1000;
+const MAX_SESSION_PREVIEWS = 4;
+const MAX_LABEL_LENGTH = 80;
 const DEFAULT_RETENTION_DAYS = 60;
 
 export interface GalleryPaths {
@@ -257,15 +259,20 @@ function summarize(payload: SessionPayload): SessionSummary {
   };
   let assetCount = 0;
   const modalities = new Set<string>();
+  const previews: SessionSummary["previews"] = [];
   for (const r of payload.runs) {
     if (r.modality) modalities.add(r.modality);
     for (const f of r.files) {
       kindCounts[f.kind] = (kindCounts[f.kind] ?? 0) + 1;
       assetCount += 1;
+      if (previews.length < MAX_SESSION_PREVIEWS) {
+        previews.push({ kind: f.kind, file: f.path, url: f.url });
+      }
     }
   }
   return {
     session_id: payload.session_id,
+    label: payload.label ?? null,
     agent: payload.agent,
     agent_host: payload.agent_host,
     started_at: payload.started_at,
@@ -274,6 +281,7 @@ function summarize(payload: SessionPayload): SessionSummary {
     asset_count: assetCount,
     kind_counts: kindCounts,
     modalities: Array.from(modalities),
+    previews,
   };
 }
 
@@ -414,6 +422,40 @@ export function recordRun(input: RecordRunInput): GalleryPaths | null {
     return null;
   }
 }
+
+export type RenameResult =
+  | { ok: true; label: string | null }
+  | { ok: false; reason: "not-found" | "too-long" | "write-failed" };
+
+// Sets or clears the cosmetic display label for a session. The on-disk id
+// stays anchored to the process-tree resolver so future runs still write
+// here — labels are an overlay, not a rename.
+export function renameSession(
+  sessionId: string,
+  rawLabel: string | null,
+): RenameResult {
+  const paths = galleryPaths(sessionId);
+  const payload = readSessionPayload(paths);
+  if (!payload) return { ok: false, reason: "not-found" };
+  const trimmed = rawLabel === null ? null : rawLabel.trim();
+  if (trimmed !== null && trimmed.length > MAX_LABEL_LENGTH) {
+    return { ok: false, reason: "too-long" };
+  }
+  if (trimmed === null || trimmed === "") {
+    delete payload.label;
+  } else {
+    payload.label = trimmed;
+  }
+  try {
+    writeSessionPayload(paths, payload);
+    regenerateRootIndexHtml();
+    return { ok: true, label: payload.label ?? null };
+  } catch {
+    return { ok: false, reason: "write-failed" };
+  }
+}
+
+export const LABEL_MAX_LENGTH = MAX_LABEL_LENGTH;
 
 export interface ClearOptions {
   sessionId?: string;

--- a/src/lib/gallery.ts
+++ b/src/lib/gallery.ts
@@ -1,0 +1,538 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { extname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { CONFIG_DIR } from "./config";
+import {
+  type AssetKind,
+  type GalleryFile,
+  type RunRecord,
+  renderSessionHtml,
+  renderSessionsIndexHtml,
+  type SessionPayload,
+  type SessionSummary,
+} from "./gallery-template";
+import { getSessionContext } from "./session";
+
+export type { AssetKind, GalleryFile, RunRecord, SessionSummary };
+
+// Root paths are computed lazily through these helpers so tests can redirect
+// the entire gallery tree to a tmpdir via `setGalleryRoot`. Production
+// callers see the standard `~/.genmedia/gallery` path with no change.
+let _rootOverride: string | null = null;
+
+export function setGalleryRoot(path: string | null): void {
+  _rootOverride = path;
+}
+
+export function galleryDir(): string {
+  return _rootOverride ?? join(CONFIG_DIR, "gallery");
+}
+
+export function sessionsDir(): string {
+  return join(galleryDir(), "sessions");
+}
+
+export function rootIndexPath(): string {
+  return join(galleryDir(), "index.html");
+}
+
+export function rootIndexUrl(): string {
+  return pathToFileURL(rootIndexPath()).toString();
+}
+
+function lastSessionPath(): string {
+  return join(galleryDir(), "last-session.json");
+}
+
+const DATA_FILE = "data.json";
+const PAGE_FILE = "index.html";
+const MAX_RUNS_PER_SESSION = 1000;
+const DEFAULT_RETENTION_DAYS = 60;
+
+export interface GalleryPaths {
+  session_id: string;
+  dir: string;
+  data_path: string;
+  index_path: string;
+  index_url: string;
+  index_root_url: string;
+}
+
+export interface RecordRunInput {
+  ts: number;
+  request_id: string;
+  endpoint_id: string;
+  modality: string | null;
+  prompt: string | null;
+  duration_ms: number | null;
+  files: GalleryFile[];
+}
+
+const KIND_BY_EXT: Record<string, AssetKind> = {
+  ".jpg": "image",
+  ".jpeg": "image",
+  ".png": "image",
+  ".gif": "image",
+  ".webp": "image",
+  ".svg": "image",
+  ".avif": "image",
+  ".heic": "image",
+  ".mp4": "video",
+  ".webm": "video",
+  ".mov": "video",
+  ".m4v": "video",
+  ".mp3": "audio",
+  ".wav": "audio",
+  ".ogg": "audio",
+  ".flac": "audio",
+  ".m4a": "audio",
+  ".glb": "model",
+  ".obj": "model",
+  ".gltf": "model",
+};
+
+const KIND_BY_MIME_PREFIX: Array<{ prefix: string; kind: AssetKind }> = [
+  { prefix: "image/", kind: "image" },
+  { prefix: "video/", kind: "video" },
+  { prefix: "audio/", kind: "audio" },
+  { prefix: "model/", kind: "model" },
+];
+
+export function kindFor(opts: {
+  path?: string | null;
+  url?: string;
+  contentType?: string;
+}): AssetKind {
+  if (opts.path) {
+    const k = KIND_BY_EXT[extname(opts.path).toLowerCase()];
+    if (k) return k;
+  }
+  if (opts.url) {
+    try {
+      const { pathname } = new URL(opts.url);
+      const k = KIND_BY_EXT[extname(pathname).toLowerCase()];
+      if (k) return k;
+    } catch {
+      // ignore parse errors
+    }
+  }
+  if (opts.contentType) {
+    const base = opts.contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+    for (const { prefix, kind } of KIND_BY_MIME_PREFIX) {
+      if (base.startsWith(prefix)) return kind;
+    }
+  }
+  return "other";
+}
+
+// Gates *recording*. Reads (list/open/clear) intentionally ignore this so a
+// user who disabled recording can still inspect or purge prior galleries.
+export function isGalleryDisabled(): boolean {
+  const v = process.env.GENMEDIA_NO_GALLERY;
+  return v === "1" || v === "true";
+}
+
+function retentionDays(): number {
+  const raw = process.env.GENMEDIA_GALLERY_RETENTION_DAYS;
+  if (!raw) return DEFAULT_RETENTION_DAYS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_RETENTION_DAYS;
+}
+
+function ensureDir(path: string): void {
+  if (!existsSync(path)) mkdirSync(path, { recursive: true });
+}
+
+export function galleryPaths(sessionId: string): GalleryPaths {
+  const dir = join(sessionsDir(), sessionId);
+  const indexPath = join(dir, PAGE_FILE);
+  return {
+    session_id: sessionId,
+    dir,
+    data_path: join(dir, DATA_FILE),
+    index_path: indexPath,
+    index_url: pathToFileURL(indexPath).toString(),
+    index_root_url: rootIndexUrl(),
+  };
+}
+
+function readSessionPayload(paths: GalleryPaths): SessionPayload | null {
+  if (!existsSync(paths.data_path)) return null;
+  try {
+    const raw = readFileSync(paths.data_path, "utf-8");
+    const parsed = JSON.parse(raw) as SessionPayload;
+    if (parsed.schema_version !== 1 || !Array.isArray(parsed.runs)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionHtml(paths: GalleryPaths, payload: SessionPayload): void {
+  writeFileSync(paths.index_path, renderSessionHtml(payload), "utf-8");
+}
+
+function writeSessionPayload(
+  paths: GalleryPaths,
+  payload: SessionPayload,
+): void {
+  ensureDir(paths.dir);
+  writeFileSync(paths.data_path, JSON.stringify(payload, null, 2), "utf-8");
+  writeSessionHtml(paths, payload);
+}
+
+// Re-renders the session HTML from its on-disk data.json using the *current*
+// bundled template + VERSION. Best-effort: returns false (no throw) when the
+// session has no recorded data or the write fails. Use from any read path
+// that's about to hand the user a file:// URL — guarantees the page they
+// open matches the CLI version that just emitted the URL.
+export function regenerateSessionHtml(sessionId: string): boolean {
+  const paths = galleryPaths(sessionId);
+  const payload = readSessionPayload(paths);
+  if (!payload) return false;
+  try {
+    ensureDir(paths.dir);
+    writeSessionHtml(paths, payload);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Re-renders the root all-sessions index. Same best-effort contract as
+// regenerateSessionHtml.
+export function regenerateRootIndexHtml(): boolean {
+  try {
+    ensureDir(galleryDir());
+    writeFileSync(
+      rootIndexPath(),
+      renderSessionsIndexHtml(listSessions()),
+      "utf-8",
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function emptyPayload(sessionId: string): SessionPayload {
+  const ctx = getSessionContext();
+  const now = Date.now();
+  return {
+    schema_version: 1,
+    session_id: sessionId,
+    session_source: ctx.source,
+    agent: ctx.agent,
+    agent_host: ctx.agentHost,
+    cwd: safeCwd(),
+    started_at: now,
+    updated_at: now,
+    runs: [],
+  };
+}
+
+function safeCwd(): string | null {
+  try {
+    return process.cwd();
+  } catch {
+    return null;
+  }
+}
+
+function summarize(payload: SessionPayload): SessionSummary {
+  const kindCounts: Record<AssetKind, number> = {
+    image: 0,
+    video: 0,
+    audio: 0,
+    model: 0,
+    other: 0,
+  };
+  let assetCount = 0;
+  const modalities = new Set<string>();
+  for (const r of payload.runs) {
+    if (r.modality) modalities.add(r.modality);
+    for (const f of r.files) {
+      kindCounts[f.kind] = (kindCounts[f.kind] ?? 0) + 1;
+      assetCount += 1;
+    }
+  }
+  return {
+    session_id: payload.session_id,
+    agent: payload.agent,
+    agent_host: payload.agent_host,
+    started_at: payload.started_at,
+    updated_at: payload.updated_at,
+    run_count: payload.runs.length,
+    asset_count: assetCount,
+    kind_counts: kindCounts,
+    modalities: Array.from(modalities),
+  };
+}
+
+export function listSessions(): SessionSummary[] {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) return [];
+  const out: SessionSummary[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const paths = galleryPaths(entry.name);
+    const payload = readSessionPayload(paths);
+    if (!payload) continue;
+    out.push(summarize(payload));
+  }
+  out.sort((a, b) => b.updated_at - a.updated_at);
+  return out;
+}
+
+// Last-recorded session pointer. Lets `gallery open latest` reattach to the
+// most-recent session even from a shell that wouldn't otherwise resolve to
+// the same session id (e.g. a user opens a new terminal after their agent
+// finished generating assets).
+export interface LastSessionPointer {
+  session_id: string;
+  anchor: string;
+  agent: string | null;
+  agent_host: string | null;
+  source: string;
+  updated_at: number;
+}
+
+export function readLastSession(): LastSessionPointer | null {
+  const p = lastSessionPath();
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as LastSessionPointer;
+    if (typeof parsed?.session_id !== "string" || parsed.session_id === "") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastSession(value: LastSessionPointer): void {
+  try {
+    ensureDir(galleryDir());
+    writeFileSync(lastSessionPath(), JSON.stringify(value, null, 2), "utf-8");
+  } catch {
+    // ignore — pointer is a hint, not load-bearing
+  }
+}
+
+// Best-effort latest-session resolver. Prefers the explicit pointer file
+// (cheap, accurate), falls back to scanning sessions/ if the pointer is
+// missing or stale.
+export function resolveLatestSessionId(): string | null {
+  const last = readLastSession();
+  if (last?.session_id) {
+    const dir = join(sessionsDir(), last.session_id);
+    if (existsSync(dir)) return last.session_id;
+  }
+  const sessions = listSessions();
+  return sessions[0]?.session_id ?? null;
+}
+
+function pruneOldSessions(retentionMs: number): void {
+  const dir = sessionsDir();
+  if (!existsSync(dir)) return;
+  const cutoff = Date.now() - retentionMs;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const subDir = join(dir, entry.name);
+    try {
+      const dataPath = join(subDir, DATA_FILE);
+      const mtime = existsSync(dataPath)
+        ? statSync(dataPath).mtimeMs
+        : statSync(subDir).mtimeMs;
+      if (mtime < cutoff) {
+        rmSync(subDir, { recursive: true, force: true });
+      }
+    } catch {
+      // skip on stat / rm errors
+    }
+  }
+}
+
+// Records a run and refreshes the static gallery files. Always returns
+// (never throws) — gallery problems must not break the underlying CLI run.
+export function recordRun(input: RecordRunInput): GalleryPaths | null {
+  if (isGalleryDisabled()) return null;
+  if (input.files.length === 0) return null;
+
+  try {
+    const ctx = getSessionContext();
+    const paths = galleryPaths(ctx.id);
+    ensureDir(galleryDir());
+    ensureDir(sessionsDir());
+    ensureDir(paths.dir);
+
+    const payload = readSessionPayload(paths) ?? emptyPayload(ctx.id);
+    payload.agent = payload.agent ?? ctx.agent;
+    payload.agent_host = payload.agent_host ?? ctx.agentHost;
+    payload.session_source = payload.session_source || ctx.source;
+    payload.updated_at = Math.max(payload.updated_at, input.ts);
+
+    const run: RunRecord = {
+      ts: input.ts,
+      request_id: input.request_id,
+      endpoint_id: input.endpoint_id,
+      modality: input.modality,
+      prompt: input.prompt,
+      duration_ms: input.duration_ms,
+      files: input.files,
+    };
+    payload.runs.push(run);
+
+    if (payload.runs.length > MAX_RUNS_PER_SESSION) {
+      payload.runs.splice(0, payload.runs.length - MAX_RUNS_PER_SESSION);
+    }
+
+    writeSessionPayload(paths, payload);
+    writeLastSession({
+      session_id: payload.session_id,
+      anchor: ctx.anchor,
+      agent: payload.agent,
+      agent_host: payload.agent_host,
+      source: payload.session_source,
+      updated_at: payload.updated_at,
+    });
+
+    pruneOldSessions(retentionDays() * 24 * 60 * 60 * 1000);
+    regenerateRootIndexHtml();
+
+    return paths;
+  } catch {
+    return null;
+  }
+}
+
+export interface ClearOptions {
+  sessionId?: string;
+  all?: boolean;
+}
+
+export interface ClearResult {
+  cleared: string[];
+}
+
+export function clearGallery(opts: ClearOptions = {}): ClearResult {
+  const cleared: string[] = [];
+  const sessions = sessionsDir();
+  const idx = rootIndexPath();
+  const lastPtr = lastSessionPath();
+
+  if (!existsSync(sessions)) {
+    if (opts.all && existsSync(idx)) {
+      try {
+        rmSync(idx, { force: true });
+      } catch {
+        // ignore
+      }
+    }
+    if (opts.all && existsSync(lastPtr)) {
+      try {
+        rmSync(lastPtr, { force: true });
+      } catch {
+        // ignore
+      }
+    }
+    return { cleared };
+  }
+
+  if (opts.sessionId) {
+    const dir = join(sessions, opts.sessionId);
+    if (existsSync(dir)) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+        cleared.push(opts.sessionId);
+      } catch {
+        // ignore
+      }
+    }
+    // If we just cleared the session the pointer points at, drop the pointer
+    // too so `gallery open latest` won't 404.
+    const last = readLastSession();
+    if (last?.session_id === opts.sessionId && existsSync(lastPtr)) {
+      try {
+        rmSync(lastPtr, { force: true });
+      } catch {
+        // ignore
+      }
+    }
+  } else if (opts.all) {
+    for (const entry of readdirSync(sessions, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      try {
+        rmSync(join(sessions, entry.name), {
+          recursive: true,
+          force: true,
+        });
+        cleared.push(entry.name);
+      } catch {
+        // ignore
+      }
+    }
+    if (existsSync(lastPtr)) {
+      try {
+        rmSync(lastPtr, { force: true });
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  try {
+    regenerateRootIndexHtml();
+  } catch {
+    // ignore
+  }
+  return { cleared };
+}
+
+// Builds GalleryFile records from the run result + (optionally) downloaded
+// local paths. Each local download is paired back with its source URL by
+// json_path, which extractMediaRefs() and downloadMedia() both carry through.
+export function buildGalleryFiles(
+  refs: ReadonlyArray<{
+    url: string;
+    contentType?: string;
+    fileSize?: number;
+    jsonPath: string;
+  }>,
+  downloaded: ReadonlyArray<{
+    url: string;
+    path: string;
+    size_bytes: number;
+    json_path: string;
+  }> = [],
+): GalleryFile[] {
+  const byJsonPath = new Map<string, (typeof downloaded)[number]>();
+  const byUrl = new Map<string, (typeof downloaded)[number]>();
+  for (const d of downloaded) {
+    byJsonPath.set(d.json_path, d);
+    byUrl.set(d.url, d);
+  }
+  return refs.map((ref) => {
+    const local = byJsonPath.get(ref.jsonPath) ?? byUrl.get(ref.url) ?? null;
+    return {
+      path: local?.path ?? null,
+      url: ref.url,
+      size_bytes: local?.size_bytes ?? ref.fileSize ?? null,
+      kind: kindFor({
+        path: local?.path,
+        url: ref.url,
+        contentType: ref.contentType,
+      }),
+      json_path: ref.jsonPath,
+    };
+  });
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -207,7 +207,14 @@ function printJobView(
   options: OutputOptions,
   writeLine: (line?: string) => void,
 ): void {
-  const { logs, result, downloaded_files, download_failures, ...rest } = data;
+  const {
+    logs,
+    result,
+    downloaded_files,
+    download_failures,
+    gallery,
+    ...rest
+  } = data;
   const status =
     typeof data.status === "string"
       ? data.status
@@ -242,6 +249,11 @@ function printJobView(
     writeLine();
     writeLine(colors.bold(colors.red("Download failures")));
     printDownloadFailures(download_failures, writeLine);
+  }
+
+  if (isRecord(gallery) && typeof gallery.url === "string") {
+    writeLine();
+    writeLine(`${colors.bold("Gallery:")} ${colors.cyan(gallery.url)}`);
   }
 
   if (Array.isArray(logs) && logs.length > 0) {

--- a/src/lib/process-tree.test.ts
+++ b/src/lib/process-tree.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import {
+  commBasename,
+  findAgentAncestor,
+  matchAgentProcess,
+  parseProcessTable,
+  walkAncestors,
+} from "./process-tree";
+
+describe("commBasename", () => {
+  test("returns the basename of a path-like comm", () => {
+    expect(commBasename("/usr/local/bin/claude")).toBe("claude");
+    expect(commBasename("/Applications/Cursor.app/Contents/MacOS/Cursor")).toBe(
+      "Cursor",
+    );
+  });
+
+  test("strips trailing args / descriptions after the executable name", () => {
+    expect(
+      commBasename(
+        "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper.app/Contents/MacOS/Cursor Helper",
+      ),
+    ).toBe("Cursor");
+    expect(commBasename("/usr/bin/zsh -l")).toBe("zsh");
+  });
+
+  test("falls back to the first token when there is no path separator (macOS comm descriptions)", () => {
+    // What `ps -e -o comm=` actually returns for a Cursor extension-host
+    // process on macOS — no path, just a setproctitle description.
+    expect(
+      commBasename("Cursor Helper (Plugin): extension-host  falgen-cli [1-7]"),
+    ).toBe("Cursor");
+  });
+
+  test("handles bare names", () => {
+    expect(commBasename("claude")).toBe("claude");
+    expect(commBasename("codex")).toBe("codex");
+  });
+
+  test("handles Windows-style backslash paths", () => {
+    expect(commBasename("C:\\bin\\codex.exe")).toBe("codex.exe");
+  });
+});
+
+describe("matchAgentProcess", () => {
+  test("recognizes known agent binaries by basename", () => {
+    expect(matchAgentProcess("/usr/local/bin/claude")).toEqual({
+      agent: "claude-code",
+    });
+    expect(matchAgentProcess("claude-code")).toEqual({ agent: "claude-code" });
+    expect(matchAgentProcess("/Users/me/.local/bin/codex")).toEqual({
+      agent: "codex",
+    });
+    expect(matchAgentProcess("cursor-agent")).toEqual({
+      agent: "cursor-agent",
+    });
+    expect(matchAgentProcess("/usr/bin/amp")).toEqual({ agent: "amp" });
+    expect(matchAgentProcess("ampcode")).toEqual({ agent: "amp" });
+    expect(matchAgentProcess("aider")).toEqual({ agent: "aider" });
+  });
+
+  test("is case-insensitive", () => {
+    expect(matchAgentProcess("/usr/bin/CLAUDE")).toEqual({
+      agent: "claude-code",
+    });
+  });
+
+  test("tolerates the .exe suffix (Windows-style)", () => {
+    expect(matchAgentProcess("C:\\bin\\codex.exe")).not.toBe(null);
+  });
+
+  test("returns null for unrelated processes", () => {
+    expect(matchAgentProcess("/bin/zsh")).toBe(null);
+    expect(matchAgentProcess("/usr/local/bin/genmedia")).toBe(null);
+    expect(matchAgentProcess("node")).toBe(null);
+  });
+});
+
+describe("parseProcessTable", () => {
+  test("parses standard `ps -e -o pid=,ppid=,comm=` output", () => {
+    const raw = [
+      "  100    1 /usr/sbin/init",
+      "  500  100 /bin/zsh",
+      "  600  500 /usr/local/bin/claude",
+      "  700  600 /bin/sh",
+      "  800  700 /usr/local/bin/genmedia",
+    ].join("\n");
+    const table = parseProcessTable(raw);
+    expect(table.size).toBe(5);
+    expect(table.get(800)).toEqual({
+      pid: 800,
+      ppid: 700,
+      comm: "/usr/local/bin/genmedia",
+    });
+    expect(table.get(600)?.comm).toBe("/usr/local/bin/claude");
+  });
+
+  test("handles spaces inside comm (macOS multi-word descriptions)", () => {
+    const raw = "  500  100 Cursor Helper (Plugin): extension-host";
+    const table = parseProcessTable(raw);
+    expect(table.get(500)?.comm).toBe("Cursor Helper (Plugin): extension-host");
+  });
+
+  test("ignores empty and malformed lines", () => {
+    const raw = ["", "garbage", "  100    1 init", "  abc   1 nope"].join("\n");
+    const table = parseProcessTable(raw);
+    expect(table.size).toBe(1);
+    expect(table.get(100)?.comm).toBe("init");
+  });
+});
+
+describe("walkAncestors", () => {
+  test("walks parent chain until init", () => {
+    const table = parseProcessTable(
+      [
+        "  100    1 init",
+        "  500  100 /bin/zsh",
+        "  600  500 /usr/local/bin/claude",
+        "  700  600 /bin/sh",
+        "  800  700 /usr/local/bin/genmedia",
+      ].join("\n"),
+    );
+    const ancestors = walkAncestors(table, 800);
+    expect(ancestors.map((a) => a.pid)).toEqual([800, 700, 600, 500, 100]);
+  });
+
+  test("stops at maxDepth", () => {
+    const table = parseProcessTable(
+      ["1 0 init", "2 1 a", "3 2 b", "4 3 c", "5 4 d"].join("\n"),
+    );
+    const ancestors = walkAncestors(table, 5, 2);
+    expect(ancestors.map((a) => a.pid)).toEqual([5, 4]);
+  });
+
+  test("stops cleanly when a pid is missing", () => {
+    const table = parseProcessTable(["100 0 init", "500 999 zsh"].join("\n"));
+    const ancestors = walkAncestors(table, 500);
+    expect(ancestors.map((a) => a.pid)).toEqual([500]);
+  });
+});
+
+describe("findAgentAncestor", () => {
+  test("picks the nearest known agent in the chain", () => {
+    const table = parseProcessTable(
+      [
+        "100 0 init",
+        "500 100 /bin/zsh",
+        "600 500 /usr/local/bin/claude",
+        "700 600 /bin/sh",
+        "800 700 /usr/local/bin/genmedia",
+      ].join("\n"),
+    );
+    const ancestors = walkAncestors(table, 800);
+    const match = findAgentAncestor(ancestors);
+    expect(match).toEqual({
+      pid: 600,
+      comm: "/usr/local/bin/claude",
+      agent: "claude-code",
+    });
+  });
+
+  test("returns null when no ancestor is a known agent", () => {
+    const table = parseProcessTable(
+      [
+        "100 0 init",
+        "500 100 /bin/zsh",
+        "700 500 /bin/sh",
+        "800 700 /usr/local/bin/genmedia",
+      ].join("\n"),
+    );
+    const ancestors = walkAncestors(table, 800);
+    expect(findAgentAncestor(ancestors)).toBe(null);
+  });
+
+  test("matches even when the agent is several shells away (the Claude Code case)", () => {
+    // Simulates Claude Code spawning a fresh subshell per Bash tool call. The
+    // direct parent of `genmedia` is a short-lived sh; the stable anchor is
+    // claude itself, three hops up.
+    const table = parseProcessTable(
+      [
+        "100 0 init",
+        "500 100 /bin/zsh",
+        "600 500 /usr/local/bin/claude",
+        "1701 600 /bin/sh",
+        "1702 1701 /bin/sh",
+        "1703 1702 /usr/local/bin/genmedia",
+      ].join("\n"),
+    );
+    const ancestors = walkAncestors(table, 1703);
+    const match = findAgentAncestor(ancestors);
+    expect(match?.agent).toBe("claude-code");
+    expect(match?.pid).toBe(600);
+  });
+});

--- a/src/lib/process-tree.ts
+++ b/src/lib/process-tree.ts
@@ -1,0 +1,132 @@
+import { execSync } from "node:child_process";
+
+export interface ProcessNode {
+  pid: number;
+  ppid: number;
+  comm: string;
+}
+
+export interface AgentMatch {
+  pid: number;
+  comm: string;
+  agent: string;
+}
+
+// Known agent binaries. Matched against the basename of the process command
+// (case-insensitive) so we tolerate full paths and the macOS habit of
+// reporting `/Applications/.../foo` as comm.
+const AGENT_PROCESS_PATTERNS: Array<{ re: RegExp; agent: string }> = [
+  { re: /^claude(-code)?(\.exe)?$/i, agent: "claude-code" },
+  { re: /^codex(\.exe)?$/i, agent: "codex" },
+  { re: /^cursor(-agent)?(\.exe)?$/i, agent: "cursor-agent" },
+  { re: /^(amp|ampcode)(\.exe)?$/i, agent: "amp" },
+  { re: /^gemini(-cli)?(\.exe)?$/i, agent: "gemini-cli" },
+  { re: /^(copilot(-cli)?|gh-copilot)(\.exe)?$/i, agent: "copilot-cli" },
+  { re: /^opencode(\.exe)?$/i, agent: "opencode" },
+  { re: /^aider(\.exe)?$/i, agent: "aider" },
+  { re: /^cline(\.exe)?$/i, agent: "cline" },
+];
+
+// Extracts the executable name from a `ps -o comm=` value. Handles three
+// shapes:
+//   - Plain POSIX path:           `/usr/local/bin/claude`            → claude
+//   - macOS app-bundle path:      `/Applications/Cursor.app/.../Cursor Helper` → Cursor
+//   - macOS description (no `/`): `Cursor Helper (Plugin): extension-host`     → Cursor
+//   - Windows path:               `C:\\bin\\codex.exe`                → codex.exe
+//   - Bare name:                  `claude`                             → claude
+// Strategy: take everything after the last `/` or `\`, then drop anything
+// from the first whitespace onwards. Good enough to match against the
+// known-agent pattern list without false positives.
+export function commBasename(comm: string): string {
+  const lastSlash = Math.max(comm.lastIndexOf("/"), comm.lastIndexOf("\\"));
+  const tail = lastSlash >= 0 ? comm.slice(lastSlash + 1) : comm;
+  const firstSpace = tail.search(/\s/);
+  return firstSpace >= 0 ? tail.slice(0, firstSpace) : tail;
+}
+
+export function matchAgentProcess(comm: string): { agent: string } | null {
+  const base = commBasename(comm);
+  for (const { re, agent } of AGENT_PROCESS_PATTERNS) {
+    if (re.test(base)) return { agent };
+  }
+  return null;
+}
+
+const PS_LINE_RE = /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/;
+
+export function parseProcessTable(raw: string): Map<number, ProcessNode> {
+  const map = new Map<number, ProcessNode>();
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const m = line.match(PS_LINE_RE);
+    if (!m) continue;
+    const pid = Number.parseInt(m[1], 10);
+    const ppid = Number.parseInt(m[2], 10);
+    const comm = m[3].trim();
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    map.set(pid, { pid, ppid, comm });
+  }
+  return map;
+}
+
+let _cachedTable: Map<number, ProcessNode> | null = null;
+
+// Reads `ps -e` once per process. Returns an empty map when unavailable
+// (Windows, sandboxed environments, or if `ps` exits with an error).
+export function readProcessTable(): Map<number, ProcessNode> {
+  if (_cachedTable !== null) return _cachedTable;
+  if (process.platform === "win32") {
+    _cachedTable = new Map();
+    return _cachedTable;
+  }
+  try {
+    const out = execSync("ps -e -o pid=,ppid=,comm=", {
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+    _cachedTable = parseProcessTable(out);
+  } catch {
+    _cachedTable = new Map();
+  }
+  return _cachedTable;
+}
+
+export function walkAncestors(
+  table: Map<number, ProcessNode>,
+  startPid: number,
+  maxDepth = 16,
+): ProcessNode[] {
+  const out: ProcessNode[] = [];
+  const seen = new Set<number>();
+  let pid = startPid;
+  for (let i = 0; i < maxDepth; i++) {
+    if (seen.has(pid)) break;
+    seen.add(pid);
+    const node = table.get(pid);
+    if (!node) break;
+    out.push(node);
+    if (node.ppid <= 1 || node.ppid === node.pid) break;
+    pid = node.ppid;
+  }
+  return out;
+}
+
+export function findAgentAncestor(ancestors: ProcessNode[]): AgentMatch | null {
+  for (const a of ancestors) {
+    const m = matchAgentProcess(a.comm);
+    if (m) {
+      return { pid: a.pid, comm: a.comm, agent: m.agent };
+    }
+  }
+  return null;
+}
+
+// Convenience: read the live process table and return the agent match (if
+// any) starting from the given pid. Cached.
+export function findAgentInTree(startPid: number): AgentMatch | null {
+  const table = readProcessTable();
+  if (table.size === 0) return null;
+  const ancestors = walkAncestors(table, startPid);
+  return findAgentAncestor(ancestors);
+}

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import type { ProcessNode } from "./process-tree";
+import { hashSessionAnchor, resolveSession } from "./session";
+
+function makeAncestors(rows: Array<[number, number, string]>): ProcessNode[] {
+  return rows.map(([pid, ppid, comm]) => ({ pid, ppid, comm }));
+}
+
+describe("resolveSession", () => {
+  test("explicit override beats everything", () => {
+    const out = resolveSession({
+      env: {
+        GENMEDIA_SESSION_ID: "manual-1",
+        CODEX_THREAD_ID: "codex-x",
+        TERM_SESSION_ID: "term-y",
+      },
+      ppid: 1234,
+      agent: "codex",
+    });
+    expect(out.source).toBe("override");
+    expect(out.anchor).toBe("manual-1");
+    expect(out.id).toBe(hashSessionAnchor("manual-1"));
+  });
+
+  test("Codex thread id is used when no override is set", () => {
+    const out = resolveSession({
+      env: { CODEX_THREAD_ID: "thread-abc", TERM_SESSION_ID: "term-y" },
+      ppid: 99,
+      agent: "codex",
+    });
+    expect(out.source).toBe("agent-env");
+    expect(out.anchor).toBe("thread-abc");
+    expect(out.id).toBe(hashSessionAnchor("thread-abc"));
+  });
+
+  test("Claude session id is honored", () => {
+    const out = resolveSession({
+      env: { CLAUDE_SESSION_ID: "claude-abc" },
+      ppid: 99,
+      agent: "claude-code",
+    });
+    expect(out.source).toBe("agent-env");
+    expect(out.anchor).toBe("claude-abc");
+  });
+
+  test("first agent-env key wins (CODEX_THREAD_ID before CLAUDE_SESSION_ID)", () => {
+    const out = resolveSession({
+      env: { CODEX_THREAD_ID: "codex-1", CLAUDE_SESSION_ID: "claude-1" },
+      ppid: 99,
+      agent: null,
+    });
+    expect(out.anchor).toBe("codex-1");
+  });
+
+  test("falls back to terminal session id when no agent env is set", () => {
+    const out = resolveSession({
+      env: { TERM_SESSION_ID: "iterm-7" },
+      ppid: 99,
+      agent: null,
+    });
+    expect(out.source).toBe("terminal-env");
+    expect(out.anchor).toBe("iterm-7");
+  });
+
+  test("process-tree match beats terminal-env (closes the Claude Code subshell gap)", () => {
+    // Two genmedia invocations have *different* PPIDs and *different*
+    // transient subshells, but both walk up to the same claude PID — they
+    // must resolve to the same session id.
+    const a = resolveSession({
+      env: { TERM_SESSION_ID: "iterm-7" },
+      ppid: 1701,
+      agent: "claude-code",
+      ancestors: makeAncestors([
+        [1701, 600, "/bin/sh"],
+        [600, 500, "/usr/local/bin/claude"],
+        [500, 1, "/bin/zsh"],
+      ]),
+    });
+    const b = resolveSession({
+      env: { TERM_SESSION_ID: "iterm-7" },
+      ppid: 9999,
+      agent: "claude-code",
+      ancestors: makeAncestors([
+        [9999, 600, "/bin/sh"],
+        [600, 500, "/usr/local/bin/claude"],
+        [500, 1, "/bin/zsh"],
+      ]),
+    });
+    expect(a.source).toBe("process-tree");
+    expect(a.anchor).toBe("claude-code:600");
+    expect(b.id).toBe(a.id);
+  });
+
+  test("process-tree honors codex / cursor / amp basenames", () => {
+    expect(
+      resolveSession({
+        env: {},
+        ppid: 1,
+        agent: null,
+        ancestors: makeAncestors([
+          [50, 10, "/bin/sh"],
+          [10, 1, "/usr/local/bin/codex"],
+        ]),
+      }).anchor,
+    ).toBe("codex:10");
+    expect(
+      resolveSession({
+        env: {},
+        ppid: 1,
+        agent: null,
+        ancestors: makeAncestors([
+          [50, 10, "/bin/sh"],
+          [10, 1, "/usr/local/bin/cursor-agent"],
+        ]),
+      }).anchor,
+    ).toBe("cursor-agent:10");
+    expect(
+      resolveSession({
+        env: {},
+        ppid: 1,
+        agent: null,
+        ancestors: makeAncestors([
+          [50, 10, "/bin/sh"],
+          [10, 1, "/usr/local/bin/ampcode"],
+        ]),
+      }).anchor,
+    ).toBe("amp:10");
+  });
+
+  test("agent-env still beats process-tree (explicit signals are stronger)", () => {
+    const out = resolveSession({
+      env: { CODEX_THREAD_ID: "thread-z" },
+      ppid: 5,
+      agent: "codex",
+      ancestors: makeAncestors([[10, 1, "/usr/local/bin/codex"]]),
+    });
+    expect(out.source).toBe("agent-env");
+    expect(out.anchor).toBe("thread-z");
+  });
+
+  test("process-tree falls through to terminal-env when no known agent is in the chain", () => {
+    const out = resolveSession({
+      env: { TERM_SESSION_ID: "iterm-7" },
+      ppid: 5,
+      agent: null,
+      ancestors: makeAncestors([
+        [5, 4, "/bin/sh"],
+        [4, 1, "/bin/zsh"],
+      ]),
+    });
+    expect(out.source).toBe("terminal-env");
+    expect(out.anchor).toBe("iterm-7");
+  });
+
+  test("uses TMUX_PANE when iTerm/WT are absent", () => {
+    const out = resolveSession({
+      env: { TMUX_PANE: "%42" },
+      ppid: 99,
+      agent: null,
+    });
+    expect(out.source).toBe("terminal-env");
+    expect(out.anchor).toBe("%42");
+  });
+
+  test("PPID + agent fallback when no env signals exist", () => {
+    const out = resolveSession({
+      env: {},
+      ppid: 1234,
+      agent: "claude-code",
+    });
+    expect(out.source).toBe("fallback");
+    expect(out.anchor).toBe("claude-code:1234");
+    expect(out.id).toBe(hashSessionAnchor("claude-code:1234"));
+  });
+
+  test("fallback uses 'user' when no agent is detected", () => {
+    const out = resolveSession({
+      env: {},
+      ppid: 4242,
+      agent: null,
+    });
+    expect(out.anchor).toBe("user:4242");
+  });
+
+  test("empty string env vars are treated as absent", () => {
+    const out = resolveSession({
+      env: {
+        GENMEDIA_SESSION_ID: "",
+        CODEX_THREAD_ID: "",
+        TERM_SESSION_ID: "term-1",
+      },
+      ppid: 1,
+      agent: null,
+    });
+    expect(out.source).toBe("terminal-env");
+    expect(out.anchor).toBe("term-1");
+  });
+
+  test("hashed id is filesystem-safe and 12 characters long", () => {
+    const out = resolveSession({
+      env: { GENMEDIA_SESSION_ID: "anything with /slashes and spaces" },
+      ppid: 1,
+      agent: null,
+    });
+    expect(out.id).toMatch(/^[a-f0-9]{12}$/);
+  });
+
+  test("same anchor produces the same id deterministically", () => {
+    const a = resolveSession({
+      env: { GENMEDIA_SESSION_ID: "stable" },
+      ppid: 1,
+      agent: null,
+    });
+    const b = resolveSession({
+      env: { GENMEDIA_SESSION_ID: "stable" },
+      ppid: 2,
+      agent: "different",
+    });
+    expect(a.id).toBe(b.id);
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,208 @@
+import { createHash } from "node:crypto";
+import { getCallerInfo } from "./caller";
+import {
+  type AgentMatch,
+  findAgentAncestor as findAgentInAncestors,
+  findAgentInTree,
+  type ProcessNode,
+} from "./process-tree";
+
+export type SessionSource =
+  | "override"
+  | "agent-env"
+  | "process-tree"
+  | "terminal-env"
+  | "fallback";
+
+export interface SessionContext {
+  id: string;
+  source: SessionSource;
+  agent: string | null;
+  agentHost: string | null;
+  anchor: string;
+  startedAt: number;
+}
+
+// Inputs we read from the environment (extracted for pure testing).
+export interface SessionEnv {
+  GENMEDIA_SESSION_ID?: string;
+  CODEX_THREAD_ID?: string;
+  CLAUDE_SESSION_ID?: string;
+  AMP_THREAD_ID?: string;
+  CURSOR_TRACE_ID?: string;
+  TERM_SESSION_ID?: string;
+  ITERM_SESSION_ID?: string;
+  WT_SESSION?: string;
+  TMUX_PANE?: string;
+}
+
+export interface SessionInputs {
+  env: SessionEnv;
+  ppid: number;
+  agent: string | null;
+  // Optional pre-computed ancestor chain (closest parent first). If provided
+  // and any element matches a known agent process, that PID becomes the
+  // session anchor. Tests pass synthetic chains; the live entrypoint walks
+  // `/bin/ps -e` lazily.
+  ancestors?: ProcessNode[];
+}
+
+export interface SessionResolution {
+  id: string;
+  source: SessionSource;
+  anchor: string;
+}
+
+const AGENT_SESSION_KEYS = [
+  "CODEX_THREAD_ID",
+  "CLAUDE_SESSION_ID",
+  "AMP_THREAD_ID",
+  "CURSOR_TRACE_ID",
+] as const satisfies readonly (keyof SessionEnv)[];
+
+const TERMINAL_SESSION_KEYS = [
+  "TERM_SESSION_ID",
+  "ITERM_SESSION_ID",
+  "WT_SESSION",
+  "TMUX_PANE",
+] as const satisfies readonly (keyof SessionEnv)[];
+
+function firstNonEmpty(
+  env: SessionEnv,
+  keys: readonly (keyof SessionEnv)[],
+): string | null {
+  for (const key of keys) {
+    const v = env[key];
+    if (v !== undefined && v !== "") return v;
+  }
+  return null;
+}
+
+// Hashes any raw signal into a stable, filesystem-safe 12-char slug. We never
+// embed user-controlled strings directly in paths.
+export function hashSessionAnchor(anchor: string): string {
+  return createHash("sha1").update(anchor).digest("hex").slice(0, 12);
+}
+
+export function resolveSession(inputs: SessionInputs): SessionResolution {
+  const { env, ppid, agent, ancestors } = inputs;
+
+  const override = env.GENMEDIA_SESSION_ID;
+  if (override !== undefined && override !== "") {
+    return {
+      id: hashSessionAnchor(override),
+      source: "override",
+      anchor: override,
+    };
+  }
+
+  const agentSignal = firstNonEmpty(env, AGENT_SESSION_KEYS);
+  if (agentSignal !== null) {
+    return {
+      id: hashSessionAnchor(agentSignal),
+      source: "agent-env",
+      anchor: agentSignal,
+    };
+  }
+
+  // Process-tree walk. Critical for agents that spawn a fresh subprocess per
+  // tool call (Claude Code's Bash tool is the canonical example), where
+  // `process.ppid` differs every invocation but the agent process itself
+  // lives for the entire conversation. Using the agent PID as the anchor
+  // keeps all runs from one Claude/Codex/Cursor session in the same gallery.
+  let agentMatch: AgentMatch | null = null;
+  if (ancestors !== undefined) {
+    agentMatch = findAgentInAncestors(ancestors);
+  }
+  if (agentMatch !== null) {
+    const anchor = `${agentMatch.agent}:${agentMatch.pid}`;
+    return {
+      id: hashSessionAnchor(anchor),
+      source: "process-tree",
+      anchor,
+    };
+  }
+
+  const terminalSignal = firstNonEmpty(env, TERMINAL_SESSION_KEYS);
+  if (terminalSignal !== null) {
+    return {
+      id: hashSessionAnchor(terminalSignal),
+      source: "terminal-env",
+      anchor: terminalSignal,
+    };
+  }
+
+  // PPID-based fallback: stable when the parent shell lives across multiple
+  // genmedia invocations. Not reliable for agents that spawn a transient
+  // shell per tool call — those should match the process-tree tier above.
+  const anchor = `${agent ?? "user"}:${ppid}`;
+  return {
+    id: hashSessionAnchor(anchor),
+    source: "fallback",
+    anchor,
+  };
+}
+
+function readSessionEnv(): SessionEnv {
+  return {
+    GENMEDIA_SESSION_ID: process.env.GENMEDIA_SESSION_ID,
+    CODEX_THREAD_ID: process.env.CODEX_THREAD_ID,
+    CLAUDE_SESSION_ID: process.env.CLAUDE_SESSION_ID,
+    AMP_THREAD_ID: process.env.AMP_THREAD_ID,
+    CURSOR_TRACE_ID: process.env.CURSOR_TRACE_ID,
+    TERM_SESSION_ID: process.env.TERM_SESSION_ID,
+    ITERM_SESSION_ID: process.env.ITERM_SESSION_ID,
+    WT_SESSION: process.env.WT_SESSION,
+    TMUX_PANE: process.env.TMUX_PANE,
+  };
+}
+
+function shouldWalkProcessTree(env: SessionEnv): boolean {
+  if (env.GENMEDIA_SESSION_ID) return false;
+  if (env.CODEX_THREAD_ID) return false;
+  if (env.CLAUDE_SESSION_ID) return false;
+  if (env.AMP_THREAD_ID) return false;
+  if (env.CURSOR_TRACE_ID) return false;
+  return true;
+}
+
+let _cached: SessionContext | null = null;
+
+export function getSessionContext(): SessionContext {
+  if (_cached !== null) return _cached;
+  const caller = getCallerInfo();
+  const env = readSessionEnv();
+
+  // Lazy `ps -e` walk: only fork it when no explicit session env is set,
+  // because the higher-priority tiers would short-circuit before reading
+  // the ancestor chain anyway.
+  const agentMatch = shouldWalkProcessTree(env)
+    ? findAgentInTree(process.ppid ?? 0)
+    : null;
+  // resolveSession expects an ancestors array; collapse the lazy lookup
+  // into a one-element synthetic chain (the matched agent), which makes
+  // findAgentAncestor return it immediately.
+  const ancestors = agentMatch
+    ? [{ pid: agentMatch.pid, ppid: 0, comm: agentMatch.comm }]
+    : undefined;
+
+  const resolution = resolveSession({
+    env,
+    ppid: process.ppid ?? 0,
+    agent: caller.agent,
+    ancestors,
+  });
+  _cached = {
+    id: resolution.id,
+    source: resolution.source,
+    anchor: resolution.anchor,
+    agent: caller.agent,
+    agentHost: caller.agentHost,
+    startedAt: Date.now(),
+  };
+  return _cached;
+}
+
+export function getSessionId(): string {
+  return getSessionContext().id;
+}

--- a/src/types/text-imports.d.ts
+++ b/src/types/text-imports.d.ts
@@ -1,0 +1,20 @@
+// Allows `import text from "./path" with { type: "text" }` for assets the
+// Bun bundler should embed verbatim. Bun reads these from disk in dev and
+// inlines them as string constants at `bun build --compile` time.
+//
+// The HTML gallery templates are named `*.html.tmpl` (not `*.html`) on
+// purpose: Bun's HTML loader otherwise runs on `*.html` files in the
+// import graph and corrupts `{{{...}}}` template placeholders inside
+// `<script>` blocks (see comment in gallery-template.ts).
+declare module "*.css" {
+  const content: string;
+  export default content;
+}
+declare module "*.client.js" {
+  const content: string;
+  export default content;
+}
+declare module "*.html.tmpl" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary

- Adds `genmedia gallery` (+ `info` / `open` / `list` / `clear`) for browsing a per-session, self-contained static HTML preview of every image / video / audio / 3D asset produced by `run` and `status --download`. Lives at `~/.genmedia/gallery/sessions/<session_id>/index.html` — no server, opens straight from `file://`.
- `run` and `status` responses now include a `gallery: { session_id, path, url }` block, and JSON help schema in `src/index.ts` is updated to document the new fields and subcommands.
- Session resolution walks the process tree (Claude / Codex / Cursor / Amp / Gemini / Aider / Cline / OpenCode / Copilot) so Claude Code's per-Bash-invocation shells still resolve to the long-lived agent process. Override via `GENMEDIA_SESSION_ID`; disable recording via `GENMEDIA_NO_GALLERY=1`; tune retention via `GENMEDIA_GALLERY_RETENTION_DAYS` (default 60d).
- `gallery clear` always requires `--yes` — never prompts — so it stays safe for agents and humans alike. Recording can be disabled while `list` / `open` / `clear` still work against prior sessions.
- Bundled gallery assets (HTML template + CSS + tiny client JS) live in `src/lib/gallery-assets/` and are loaded via a new `src/types/text-imports.d.ts` module declaration. The page auto-refreshes from `./data.json` while the session is live (last 5 min).

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun run build` passes
- [x] `bun test src/lib/gallery.test.ts src/lib/session.test.ts src/lib/process-tree.test.ts src/commands/gallery/gallery.test.ts`
- [x] `genmedia gallery` from a fresh shell prints session info JSON
- [x] `genmedia run ...` records a file and `gallery: { ... }` appears in the JSON response
- [x] `genmedia gallery open` opens the all-sessions index, `open latest` opens the most-recent session
- [x] `genmedia gallery open latest --print` resolves without launching a browser
- [x] `genmedia gallery list --limit 5` returns the newest 5 sessions
- [x] `genmedia gallery clear` errors without `--yes`; `genmedia gallery clear --yes` deletes the current session
- [x] `GENMEDIA_NO_GALLERY=1 genmedia run ...` produces no gallery field but `gallery list` still works
- [x] Open `index.html` for a live session and confirm new runs land in the open tab without manual refresh