### PR TITLE
feat(gallery): Gallery UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ genmedia gallery open <session_id>        # open a specific session
 genmedia gallery open latest --print      # resolve path/url without launching the browser
 genmedia gallery list                     # list every recorded session (newest first, JSON-friendly)
 genmedia gallery list --limit 10          # cap the list (default: 50)
+genmedia gallery rename --label "demo run"        # rename the current session (cosmetic — id stays the same)
+genmedia gallery rename latest --label "x"        # rename the most-recent session
+genmedia gallery rename <session_id> --clear      # remove a session's label
 genmedia gallery clear --yes              # delete the current session (--yes is required)
 genmedia gallery clear latest --yes       # delete the most-recently recorded session
 genmedia gallery clear <session_id> --yes # delete a specific session

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Shows the current version and flags any known update (populated by the backgroun
 Every successful `genmedia run` (and `genmedia status --download`) records its outputs into a per-session, self-contained static HTML page under `~/.genmedia/gallery/sessions/<session_id>/index.html`. The page aggregates every image / video / audio / 3D asset produced inside one agent session — across many runs and many endpoints — into a filterable grid with a lightbox view. No server, no dependencies, opens straight from `file://`.
 
 ```bash
-genmedia gallery                          # print { session_id, path, url } for the current session
-genmedia gallery info                     # same as above (explicit form)
+genmedia gallery                          # pretty TTY: prints `→ Open: <url>`. JSON / non-TTY: full info payload.
+genmedia gallery --json                   # structured info payload, agent-safe
+genmedia gallery info                     # full info payload, even from a TTY (devs)
 genmedia gallery open                     # open the all-sessions index in the default browser
 genmedia gallery open current             # open the current session
 genmedia gallery open latest              # open the most-recently recorded session (works across shells)

--- a/src/commands/gallery/gallery.test.ts
+++ b/src/commands/gallery/gallery.test.ts
@@ -6,12 +6,14 @@ import {
   clearGallery,
   galleryDir,
   galleryPaths,
+  LABEL_MAX_LENGTH,
   listSessions,
   type RecordRunInput,
   readLastSession,
   recordRun,
   regenerateRootIndexHtml,
   regenerateSessionHtml,
+  renameSession,
   resolveLatestSessionId,
   rootIndexPath,
   rootIndexUrl,
@@ -285,6 +287,42 @@ describe("gallery storage (redirected root)", () => {
       "audio",
     ]);
     expect(previews.every((p) => !p.url.endsWith(".glb"))).toBe(true);
+  });
+
+  test("renameSession sets, trims, clears, and exposes label via listSessions", () => {
+    const paths = recordRun(makeRun("a"));
+    const id = paths?.session_id ?? "";
+
+    // Set
+    const ok = renameSession(id, "  fluffy dog batch  ");
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.label).toBe("fluffy dog batch");
+    expect(listSessions()[0].label).toBe("fluffy dog batch");
+
+    // Clear via null
+    const cleared = renameSession(id, null);
+    expect(cleared.ok).toBe(true);
+    if (cleared.ok) expect(cleared.label).toBeNull();
+    expect(listSessions()[0].label).toBeNull();
+
+    // Clear via empty string
+    renameSession(id, "x");
+    const cleared2 = renameSession(id, "   ");
+    expect(cleared2.ok).toBe(true);
+    if (cleared2.ok) expect(cleared2.label).toBeNull();
+  });
+
+  test("renameSession rejects too-long labels and unknown ids", () => {
+    const paths = recordRun(makeRun("a"));
+    const id = paths?.session_id ?? "";
+
+    const tooLong = renameSession(id, "x".repeat(LABEL_MAX_LENGTH + 1));
+    expect(tooLong.ok).toBe(false);
+    if (!tooLong.ok) expect(tooLong.reason).toBe("too-long");
+
+    const missing = renameSession("does-not-exist", "anything");
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.reason).toBe("not-found");
   });
 
   test("GENMEDIA_NO_GALLERY blocks writes but not reads/clears", () => {

--- a/src/commands/gallery/gallery.test.ts
+++ b/src/commands/gallery/gallery.test.ts
@@ -7,6 +7,7 @@ import {
   galleryDir,
   galleryPaths,
   listSessions,
+  type RecordRunInput,
   readLastSession,
   recordRun,
   regenerateRootIndexHtml,
@@ -33,7 +34,7 @@ function fakeCtx(overrides: Partial<SessionContext> = {}): SessionContext {
   };
 }
 
-function makeRun(suffix = "1") {
+function makeRun(suffix = "1"): RecordRunInput {
   return {
     ts: Date.now(),
     request_id: `req-${suffix}`,
@@ -46,7 +47,7 @@ function makeRun(suffix = "1") {
         path: null,
         url: `https://cdn.example.com/${suffix}.png`,
         size_bytes: null,
-        kind: "image" as const,
+        kind: "image",
         json_path: `images[${suffix}]`,
       },
     ],
@@ -214,6 +215,76 @@ describe("gallery storage (redirected root)", () => {
     const fresh = readFileSync(rootIndexPath(), "utf-8");
     expect(fresh).toStartWith("<!doctype html>");
     expect(fresh).toContain('id="sessions-grid"');
+  });
+
+  test("listSessions previews mix image/video/audio, capped at 4, excludes 3d/other", () => {
+    // 2 images, 1 video, 1 audio, 2 more images, 1 model. previews
+    // should be FIFO across image+video+audio, model skipped, capped at 4.
+    recordRun(makeRun("img-a"));
+    recordRun(makeRun("img-b"));
+    recordRun({
+      ts: Date.now(),
+      request_id: "vid-1",
+      endpoint_id: "fal-ai/test",
+      modality: null,
+      prompt: null,
+      duration_ms: null,
+      files: [
+        {
+          path: "/tmp/clip.mp4",
+          url: "https://cdn.example.com/clip.mp4",
+          size_bytes: null,
+          kind: "video",
+          json_path: "video",
+        },
+      ],
+    });
+    recordRun({
+      ts: Date.now(),
+      request_id: "audio-1",
+      endpoint_id: "fal-ai/test",
+      modality: null,
+      prompt: null,
+      duration_ms: null,
+      files: [
+        {
+          path: null,
+          url: "https://cdn.example.com/voice.mp3",
+          size_bytes: null,
+          kind: "audio",
+          json_path: "audio[0]",
+        },
+      ],
+    });
+    recordRun(makeRun("img-c")); // pushes over the 4-cap
+    recordRun(makeRun("img-d"));
+    recordRun({
+      ts: Date.now(),
+      request_id: "model-1",
+      endpoint_id: "fal-ai/test",
+      modality: null,
+      prompt: null,
+      duration_ms: null,
+      files: [
+        {
+          path: null,
+          url: "https://cdn.example.com/asset.glb",
+          size_bytes: null,
+          kind: "model",
+          json_path: "model",
+        },
+      ],
+    });
+
+    const previews = listSessions()[0].previews;
+    expect(previews.length).toBe(4);
+    expect(previews.map((p) => p.kind)).toEqual([
+      "image",
+      "image",
+      "video",
+      "audio",
+    ]);
+    expect(previews.every((p) => !p.url.endsWith(".glb"))).toBe(true);
   });
 
   test("GENMEDIA_NO_GALLERY blocks writes but not reads/clears", () => {

--- a/src/commands/gallery/gallery.test.ts
+++ b/src/commands/gallery/gallery.test.ts
@@ -219,11 +219,10 @@ describe("gallery storage (redirected root)", () => {
     expect(fresh).toContain('id="sessions-grid"');
   });
 
-  test("listSessions previews mix image/video/audio, capped at 4, excludes 3d/other", () => {
-    // 2 images, 1 video, 1 audio, 2 more images, 1 model. previews
-    // should be FIFO across image+video+audio, model skipped, capped at 4.
+  test("listSessions previews include all kinds FIFO, capped at 4", () => {
+    // image, video, audio, model (in that order). All four kinds fit in
+    // the 4-slot cap and appear in chronological FIFO order.
     recordRun(makeRun("img-a"));
-    recordRun(makeRun("img-b"));
     recordRun({
       ts: Date.now(),
       request_id: "vid-1",
@@ -258,8 +257,6 @@ describe("gallery storage (redirected root)", () => {
         },
       ],
     });
-    recordRun(makeRun("img-c")); // pushes over the 4-cap
-    recordRun(makeRun("img-d"));
     recordRun({
       ts: Date.now(),
       request_id: "model-1",
@@ -277,16 +274,21 @@ describe("gallery storage (redirected root)", () => {
         },
       ],
     });
+    recordRun(makeRun("img-b")); // would be 5th — capped out
 
     const previews = listSessions()[0].previews;
     expect(previews.length).toBe(4);
     expect(previews.map((p) => p.kind)).toEqual([
       "image",
-      "image",
       "video",
       "audio",
+      "model",
     ]);
-    expect(previews.every((p) => !p.url.endsWith(".glb"))).toBe(true);
+    expect(previews[3]).toEqual({
+      kind: "model",
+      file: null,
+      url: "https://cdn.example.com/asset.glb",
+    });
   });
 
   test("renameSession sets, trims, clears, and exposes label via listSessions", () => {

--- a/src/commands/gallery/index.ts
+++ b/src/commands/gallery/index.ts
@@ -15,6 +15,7 @@ export default defineCommand({
     info: () => import("./info").then((m) => m.default),
     open: () => import("./open").then((m) => m.default),
     list: () => import("./list").then((m) => m.default),
+    rename: () => import("./rename").then((m) => m.default),
     clear: () => import("./clear").then((m) => m.default),
   },
 });

--- a/src/commands/gallery/info.ts
+++ b/src/commands/gallery/info.ts
@@ -8,61 +8,90 @@ import {
   regenerateSessionHtml,
   rootIndexUrl,
 } from "../../lib/gallery";
-import { output } from "../../lib/output";
+import { isJsonOutput, output } from "../../lib/output";
 import { getSessionContext } from "../../lib/session";
+import { colors } from "../../lib/ui";
 
-// Default subcommand. Prints the current session's gallery info — never
-// destructive, never opens a browser. Use `gallery open` for that.
 export default defineCommand({
   meta: {
     name: "info",
     description:
-      "Print the current session's gallery info (path, url, exists). Default subcommand.",
+      "Show gallery info. `gallery info` (explicit) or `--json` prints the full payload + open hint; bare `gallery` in pretty TTY prints just the hint.",
   },
   async run() {
     const ctx = getSessionContext();
     const paths = galleryPaths(ctx.id);
-    // Both URLs we emit point at on-disk HTML — refresh them against the
-    // current template so anyone clicking through gets the latest UI.
+    // Refresh on-disk HTML so the URL we hand back uses the current template.
     regenerateSessionHtml(ctx.id);
     regenerateRootIndexHtml();
     const exists = existsSync(paths.index_path);
     const last = readLastSession();
-
     const hasLatestElsewhere =
       !exists && last !== null && last.session_id !== ctx.id;
 
-    output(
-      {
-        scope: "session",
-        session_id: ctx.id,
-        session_source: ctx.source,
-        agent: ctx.agent,
-        agent_host: ctx.agentHost,
-        path: paths.index_path,
-        url: paths.index_url,
-        exists,
-        recording_disabled: isGalleryDisabled(),
-        index_url: rootIndexUrl(),
-        ...(hasLatestElsewhere
-          ? {
-              latest: {
-                session_id: last.session_id,
-                agent: last.agent,
-                updated_at: last.updated_at,
-                hint: "Open it with `genmedia gallery open latest`.",
-              },
-            }
-          : {}),
-        ...(exists
-          ? {}
-          : {
-              hint: hasLatestElsewhere
-                ? "This shell resolves to a different session than your last recording. Try `genmedia gallery open latest`."
-                : "No assets have been recorded for this session yet — run a model first.",
-            }),
-      },
-      { view: "default" },
-    );
+    // `gallery info` is the explicit "give me everything" form. Bare
+    // `gallery` (routed here via `default: "info"`) defaults to the compact
+    // open hint when stdout is pretty/TTY.
+    const explicitInfo = process.argv.includes("info");
+
+    const url = exists
+      ? paths.index_url
+      : hasLatestElsewhere
+        ? rootIndexUrl()
+        : null;
+
+    const openHint =
+      url === null
+        ? null
+        : `${colors.bold(colors.cyan("→"))} ${colors.bold("Open:")} ${colors.cyan(url)}`;
+
+    if (isJsonOutput() || explicitInfo) {
+      output(
+        {
+          scope: "session",
+          session_id: ctx.id,
+          session_source: ctx.source,
+          agent: ctx.agent,
+          agent_host: ctx.agentHost,
+          path: paths.index_path,
+          url: paths.index_url,
+          exists,
+          recording_disabled: isGalleryDisabled(),
+          index_url: rootIndexUrl(),
+          ...(hasLatestElsewhere
+            ? {
+                latest: {
+                  session_id: last.session_id,
+                  agent: last.agent,
+                  updated_at: last.updated_at,
+                  hint: "Open it with `genmedia gallery open latest`.",
+                },
+              }
+            : {}),
+          ...(exists
+            ? {}
+            : {
+                hint: hasLatestElsewhere
+                  ? "This shell resolves to a different session than your last recording. Try `genmedia gallery open latest`."
+                  : "No assets have been recorded for this session yet — run a model first.",
+              }),
+        },
+        { view: "default" },
+      );
+      if (!isJsonOutput() && openHint !== null) {
+        const rule = colors.dim("─".repeat(60));
+        process.stdout.write(`\n${rule}\n${openHint}\n`);
+      }
+      return;
+    }
+
+    if (openHint === null) {
+      process.stdout.write(
+        `${colors.dim("No assets recorded yet — run `genmedia run` to generate something.")}\n`,
+      );
+      return;
+    }
+
+    process.stdout.write(`${openHint}\n`);
   },
 });

--- a/src/commands/gallery/list.ts
+++ b/src/commands/gallery/list.ts
@@ -16,6 +16,36 @@ export function parseLimit(raw: string | undefined): number | null {
   return n;
 }
 
+const KIND_PLURAL: Record<string, string> = {
+  image: "images",
+  video: "videos",
+  audio: "audio",
+  model: "3d",
+  other: "other",
+};
+const KIND_SINGLE: Record<string, string> = {
+  image: "image",
+  video: "video",
+  audio: "audio",
+  model: "3d",
+  other: "other",
+};
+
+export function formatKindBreakdown(
+  counts: Record<string, number> | undefined,
+): string {
+  if (!counts) return "";
+  const order = ["image", "video", "audio", "model", "other"];
+  const parts: string[] = [];
+  for (const k of order) {
+    const n = counts[k] ?? 0;
+    if (!n) continue;
+    const word = n === 1 ? (KIND_SINGLE[k] ?? k) : (KIND_PLURAL[k] ?? k);
+    parts.push(`${n} ${word}`);
+  }
+  return parts.join(", ");
+}
+
 export default defineCommand({
   meta: {
     name: "list",
@@ -60,11 +90,12 @@ export default defineCommand({
       return;
     }
     for (const s of sessions) {
-      const meta = [s.agent, s.agent_host]
-        .filter((v): v is string => Boolean(v))
-        .join(" · ");
+      const labelPart = s.label ? `  ${colors.bold(s.label)}` : "";
+      const agentPart = s.agent ? `  ${colors.dim(s.agent)}` : "";
+      const breakdown = formatKindBreakdown(s.kind_counts);
+      const breakdownPart = breakdown ? `  ${colors.dim(breakdown)}` : "";
       process.stdout.write(
-        `${colors.bold(s.session_id)}  ${colors.dim(meta || "unknown agent")}  ` +
+        `${colors.bold(s.session_id)}${labelPart}${agentPart}${breakdownPart}  ` +
           `${s.asset_count} asset${s.asset_count === 1 ? "" : "s"} / ${s.run_count} run${s.run_count === 1 ? "" : "s"}  ` +
           `${colors.dim(new Date(s.updated_at).toLocaleString())}\n`,
       );

--- a/src/commands/gallery/rename.ts
+++ b/src/commands/gallery/rename.ts
@@ -1,0 +1,91 @@
+import { defineCommand } from "citty";
+import {
+  galleryPaths,
+  LABEL_MAX_LENGTH,
+  renameSession,
+  resolveLatestSessionId,
+} from "../../lib/gallery";
+import { error, output } from "../../lib/output";
+import { getSessionContext } from "../../lib/session";
+
+export default defineCommand({
+  meta: {
+    name: "rename",
+    description:
+      "Set or clear a display label for a session. The on-disk id is unchanged.",
+  },
+  args: {
+    target: {
+      type: "positional",
+      required: false,
+      description:
+        'Target: "current" (default), "latest", or a specific <session_id>',
+    },
+    label: {
+      type: "string",
+      description: `Display label (max ${LABEL_MAX_LENGTH} chars)`,
+    },
+    clear: {
+      type: "boolean",
+      description: "Remove the label instead of setting one",
+    },
+  },
+  async run({ args }) {
+    const hasLabel = typeof args.label === "string" && args.label !== "";
+    if (!hasLabel && !args.clear) {
+      error("`gallery rename` requires either --label '<name>' or --clear.", {
+        examples: [
+          "genmedia gallery rename --label 'fluffy dog batch'",
+          "genmedia gallery rename latest --label 'demo run'",
+          "genmedia gallery rename <session_id> --clear",
+        ],
+      });
+    }
+    if (hasLabel && args.clear) {
+      error("Pass --label OR --clear, not both.");
+    }
+
+    const target = (args.target ?? "current").trim();
+    let sessionId: string;
+    let source: "current" | "latest" | "explicit";
+    if (target === "latest") {
+      const id = resolveLatestSessionId();
+      if (!id) {
+        error("No recorded sessions to rename.", {
+          hint: "Run `genmedia run` first.",
+        });
+      }
+      sessionId = id;
+      source = "latest";
+    } else if (target === "current" || target === "") {
+      sessionId = getSessionContext().id;
+      source = "current";
+    } else {
+      sessionId = target;
+      source = "explicit";
+    }
+
+    const desired = args.clear ? null : (args.label as string);
+    const result = renameSession(sessionId, desired);
+    if (!result.ok) {
+      const message =
+        result.reason === "not-found"
+          ? `Session not found: ${sessionId}`
+          : result.reason === "too-long"
+            ? `Label too long — max ${LABEL_MAX_LENGTH} chars.`
+            : "Failed to write the label.";
+      error(message, { session_id: sessionId });
+    }
+
+    output(
+      {
+        scope: "rename",
+        target: source,
+        session_id: sessionId,
+        label: result.label,
+        url: galleryPaths(sessionId).index_url,
+      },
+      { view: "default" },
+    );
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,8 @@ async function startCli(): Promise<void> {
           usage: "genmedia gallery [subcommand] [target] [flags]",
           subcommands: {
             "(none)":
-              "Print current session info (path, url, exists). Never opens a browser, never deletes.",
+              "Bare `gallery` in pretty TTY prints a single `→ Open: <url>` hint. JSON / non-TTY prints the full info payload. Use `gallery info` or `--json` to force the full payload from a TTY.",
+            info: "genmedia gallery info — print the full info payload (session id, path, url, exists, latest pointer) regardless of TTY.",
             open: 'genmedia gallery open [<target>] [--print] — no target opens the all-sessions index. Targets: "current", "latest", or <session_id>. Pass --print to resolve path/url without launching the browser.',
             list: "genmedia gallery list [--limit <n>] — list recorded sessions, newest first. (default limit: 50)",
             clear:

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,8 @@ async function startCli(): Promise<void> {
             info: "genmedia gallery info — print the full info payload (session id, path, url, exists, latest pointer) regardless of TTY.",
             open: 'genmedia gallery open [<target>] [--print] — no target opens the all-sessions index. Targets: "current", "latest", or <session_id>. Pass --print to resolve path/url without launching the browser.',
             list: "genmedia gallery list [--limit <n>] — list recorded sessions, newest first. (default limit: 50)",
+            rename:
+              'genmedia gallery rename [<target>] --label "<name>" | --clear — set or remove a display label. Target = "current" (default) | "latest" | <session_id>. The on-disk session id is unchanged.',
             clear:
               'genmedia gallery clear [<target>] --yes — target = "current" (default) | "latest" | "all" | <session_id>. --yes is REQUIRED; no interactive prompt.',
           },

--- a/src/lib/gallery-assets/index.client.js
+++ b/src/lib/gallery-assets/index.client.js
@@ -21,6 +21,7 @@
       assets: assets,
       breakdown: kinds,
       modalities: s.modalities || [],
+      previews: Array.isArray(s.previews) ? s.previews : [],
       live: isLive(s.updated_at),
     };
   }
@@ -209,6 +210,52 @@
       breakdownLabels.push(H.typeLabel(k, n));
     }
 
+    let thumbsHtml = "";
+    if (s.previews && s.previews.length) {
+      const items = [];
+      for (let i = 0; i < s.previews.length; i++) {
+        const p = s.previews[i];
+        const src = H.preferredSrc(p);
+        if (!src) continue;
+        const safeSrc = H.escapeHtml(src);
+        // First-frame trick: preload only metadata + seek to 0.1s so the
+        // browser paints a static poster without streaming the whole file.
+        let media;
+        if (p.kind === "video") {
+          media =
+            '<video preload="metadata" muted playsinline src="' +
+            safeSrc +
+            '#t=0.1"></video><span class="play-badge"><span class="disc">' +
+            H.svgPlay(16) +
+            "</span></span>";
+        } else if (p.kind === "audio") {
+          // Synthetic waveform (no audio decode) — keyed off the URL so the
+          // shape is stable across renders. Real playback is on the session
+          // page; the index thumb is decorative.
+          const bars = H.generateWaveform(p.url || p.file || "", 18, 0.55);
+          let barsHtml = "";
+          for (let b = 0; b < bars.length; b++) {
+            barsHtml +=
+              '<span class="bar" style="height:' +
+              Math.max(12, bars[b] * 100) +
+              '%"></span>';
+          }
+          media =
+            '<div class="audio-thumb">' +
+            barsHtml +
+            '</div><span class="play-badge"><span class="disc">' +
+            H.svgPlay(16) +
+            "</span></span>";
+        } else {
+          media = '<img src="' + safeSrc + '" alt="" loading="lazy" />';
+        }
+        items.push('<span class="thumb">' + media + "</span>");
+      }
+      if (items.length) {
+        thumbsHtml = '<div class="sc-thumbs">' + items.join("") + "</div>";
+      }
+    }
+
     el.innerHTML =
       '<div class="sc-top">' +
       '<span class="sc-id">' +
@@ -218,6 +265,7 @@
       H.escapeHtml(agent) +
       "</span>" +
       "</div>" +
+      thumbsHtml +
       '<p class="sc-summary">' +
       "<strong>" +
       s.assets +

--- a/src/lib/gallery-assets/index.client.js
+++ b/src/lib/gallery-assets/index.client.js
@@ -194,10 +194,12 @@
     el.className = `session-card${s.live ? " live" : ""}`;
     el.href = `./sessions/${encodeURIComponent(s.session_id)}/index.html`;
 
-    const agent = s.agent || "unknown agent";
+    const agentChip = s.agent
+      ? `<span class="chip">${H.escapeHtml(s.agent)}</span>`
+      : "";
 
     const segs = [];
-    const breakdownLabels = [];
+    const breakdownIcons = [];
     const entries = Object.keys(s.breakdown || {})
       .map((k) => [k, s.breakdown[k]])
       .filter((e) => e[1] > 0)
@@ -205,9 +207,11 @@
     for (let i = 0; i < entries.length; i++) {
       const k = entries[i][0];
       const n = entries[i][1];
-      const c = (H.TYPE_INFO[k] || H.TYPE_INFO.other).color;
-      segs.push(`<span style="background:${c}; flex:${n}"></span>`);
-      breakdownLabels.push(H.typeLabel(k, n));
+      const info = H.TYPE_INFO[k] || H.TYPE_INFO.other;
+      segs.push(`<span style="background:${info.color}; flex:${n}"></span>`);
+      breakdownIcons.push(
+        `<span class="bi" style="color:${info.color}" title="${H.escapeHtml(H.typeLabel(k, n))}">${H.iconForKind(k, 12)}<span class="bn">${n}</span></span>`,
+      );
     }
 
     let thumbsHtml = "";
@@ -257,27 +261,14 @@
     }
 
     const titleText = s.label || s.session_id;
-    const subId = s.label
-      ? `<div class="sc-subid">${H.escapeHtml(s.session_id)}</div>`
-      : "";
     const idTitleAttr = s.label ? ` title="${H.escapeHtml(s.session_id)}"` : "";
     el.innerHTML =
-      `<div class="sc-top"><span class="sc-id"${idTitleAttr}>${H.escapeHtml(titleText)}</span><span class="chip">${H.escapeHtml(agent)}</span></div>` +
-      subId +
+      `<div class="sc-top"><span class="sc-id"${idTitleAttr}>${H.escapeHtml(titleText)}</span>${agentChip}</div>` +
       thumbsHtml +
       '<p class="sc-summary">' +
-      "<strong>" +
-      s.assets +
-      "</strong> " +
-      (s.assets === 1 ? "asset" : "assets") +
-      " across <strong>" +
-      s.runs +
-      "</strong> " +
-      (s.runs === 1 ? "run" : "runs") +
-      (breakdownLabels.length
-        ? '<span class="sep">\u00B7</span><span class="breakdown">' +
-          H.escapeHtml(breakdownLabels.join(", ")) +
-          "</span>"
+      `<span class="sc-totals"><strong>${s.assets}</strong> ${s.assets === 1 ? "asset" : "assets"} across <strong>${s.runs}</strong> ${s.runs === 1 ? "run" : "runs"}</span>` +
+      (breakdownIcons.length
+        ? `<span class="breakdown-icons">${breakdownIcons.join("")}</span>`
         : "") +
       "</p>" +
       '<div class="sc-typebar">' +

--- a/src/lib/gallery-assets/index.client.js
+++ b/src/lib/gallery-assets/index.client.js
@@ -179,12 +179,7 @@
       const t = order[j];
       if (!total[t]) continue;
       const c = (H.TYPE_INFO[t] || H.TYPE_INFO.other).color;
-      html +=
-        '<span class="b"><span class="sw" style="background:' +
-        c +
-        '"></span>' +
-        H.typeLabel(t, total[t]) +
-        "</span>";
+      html += `<span class="b" style="color:${c}" title="${H.escapeHtml(H.typeLabel(t, total[t]))}">${H.iconForKind(t, 12)}<span class="bn">${total[t]}</span></span>`;
     }
     root.innerHTML = html;
   }

--- a/src/lib/gallery-assets/index.client.js
+++ b/src/lib/gallery-assets/index.client.js
@@ -220,38 +220,29 @@
       for (let i = 0; i < s.previews.length; i++) {
         const p = s.previews[i];
         const src = H.preferredSrc(p);
-        if (!src) continue;
         const safeSrc = H.escapeHtml(src);
-        // First-frame trick: preload only metadata + seek to 0.1s so the
-        // browser paints a static poster without streaming the whole file.
         let media;
-        if (p.kind === "video") {
-          media =
-            '<video preload="metadata" muted playsinline src="' +
-            safeSrc +
-            '#t=0.1"></video><span class="play-badge"><span class="disc">' +
-            H.svgPlay(16) +
-            "</span></span>";
+        if (p.kind === "video" && src) {
+          // First-frame trick: preload only metadata + seek to 0.1s so the
+          // browser paints a static poster without streaming the whole file.
+          media = `<video preload="metadata" muted playsinline src="${safeSrc}#t=0.1"></video><span class="play-badge"><span class="disc">${H.svgPlay(16)}</span></span>`;
         } else if (p.kind === "audio") {
-          // Synthetic waveform (no audio decode) — keyed off the URL so the
-          // shape is stable across renders. Real playback is on the session
-          // page; the index thumb is decorative.
+          // Synthetic waveform — deterministic seed off the URL.
           const bars = H.generateWaveform(p.url || p.file || "", 18, 0.55);
           let barsHtml = "";
           for (let b = 0; b < bars.length; b++) {
-            barsHtml +=
-              '<span class="bar" style="height:' +
-              Math.max(12, bars[b] * 100) +
-              '%"></span>';
+            barsHtml += `<span class="bar" style="height:${Math.max(12, bars[b] * 100)}%"></span>`;
           }
-          media =
-            '<div class="audio-thumb">' +
-            barsHtml +
-            '</div><span class="play-badge"><span class="disc">' +
-            H.svgPlay(16) +
-            "</span></span>";
-        } else {
+          media = `<div class="audio-thumb">${barsHtml}</div><span class="play-badge"><span class="disc">${H.svgPlay(16)}</span></span>`;
+        } else if (p.kind === "image" && src) {
           media = `<img src="${safeSrc}" alt="" loading="lazy" />`;
+        } else if (p.kind === "model" || p.kind === "other") {
+          // No meaningful media — render the kind icon as a faded placeholder.
+          const info = H.TYPE_INFO[p.kind] || H.TYPE_INFO.other;
+          media = `<div class="thumb-icon" style="color:${info.color}">${H.iconForKind(p.kind, 36)}</div>`;
+        } else {
+          // Unknown kind or missing src — skip.
+          continue;
         }
         items.push(`<span class="thumb">${media}</span>`);
       }
@@ -261,9 +252,10 @@
     }
 
     const titleText = s.label || s.session_id;
+    const idClass = s.label ? "sc-id" : "sc-id mono";
     const idTitleAttr = s.label ? ` title="${H.escapeHtml(s.session_id)}"` : "";
     el.innerHTML =
-      `<div class="sc-top"><span class="sc-id"${idTitleAttr}>${H.escapeHtml(titleText)}</span>${agentChip}</div>` +
+      `<div class="sc-top"><span class="${idClass}"${idTitleAttr}>${H.escapeHtml(titleText)}</span>${agentChip}</div>` +
       thumbsHtml +
       '<p class="sc-summary">' +
       `<span class="sc-totals"><strong>${s.assets}</strong> ${s.assets === 1 ? "asset" : "assets"} across <strong>${s.runs}</strong> ${s.runs === 1 ? "run" : "runs"}</span>` +

--- a/src/lib/gallery-assets/index.client.js
+++ b/src/lib/gallery-assets/index.client.js
@@ -13,6 +13,7 @@
     const assets = s.asset_count || 0;
     return {
       session_id: s.session_id,
+      label: s.label || null,
       agent: s.agent || null,
       agent_host: s.agent_host || null,
       started_at: s.started_at || 0,
@@ -115,6 +116,7 @@
       arr = arr.filter(
         (s) =>
           s.session_id.toLowerCase().indexOf(q) !== -1 ||
+          (s.label && s.label.toLowerCase().indexOf(q) !== -1) ||
           (s.agent && s.agent.toLowerCase().indexOf(q) !== -1) ||
           (s.agent_host && s.agent_host.toLowerCase().indexOf(q) !== -1),
       );
@@ -192,9 +194,7 @@
     el.className = `session-card${s.live ? " live" : ""}`;
     el.href = `./sessions/${encodeURIComponent(s.session_id)}/index.html`;
 
-    const agent =
-      [s.agent, s.agent_host].filter(Boolean).join(" \u00B7 ") ||
-      "unknown agent";
+    const agent = s.agent || "unknown agent";
 
     const segs = [];
     const breakdownLabels = [];
@@ -211,7 +211,7 @@
     }
 
     let thumbsHtml = "";
-    if (s.previews && s.previews.length) {
+    if (s.previews?.length) {
       const items = [];
       for (let i = 0; i < s.previews.length; i++) {
         const p = s.previews[i];
@@ -247,24 +247,23 @@
             H.svgPlay(16) +
             "</span></span>";
         } else {
-          media = '<img src="' + safeSrc + '" alt="" loading="lazy" />';
+          media = `<img src="${safeSrc}" alt="" loading="lazy" />`;
         }
-        items.push('<span class="thumb">' + media + "</span>");
+        items.push(`<span class="thumb">${media}</span>`);
       }
       if (items.length) {
-        thumbsHtml = '<div class="sc-thumbs">' + items.join("") + "</div>";
+        thumbsHtml = `<div class="sc-thumbs">${items.join("")}</div>`;
       }
     }
 
+    const titleText = s.label || s.session_id;
+    const subId = s.label
+      ? `<div class="sc-subid">${H.escapeHtml(s.session_id)}</div>`
+      : "";
+    const idTitleAttr = s.label ? ` title="${H.escapeHtml(s.session_id)}"` : "";
     el.innerHTML =
-      '<div class="sc-top">' +
-      '<span class="sc-id">' +
-      H.escapeHtml(s.session_id) +
-      "</span>" +
-      '<span class="chip">' +
-      H.escapeHtml(agent) +
-      "</span>" +
-      "</div>" +
+      `<div class="sc-top"><span class="sc-id"${idTitleAttr}>${H.escapeHtml(titleText)}</span><span class="chip">${H.escapeHtml(agent)}</span></div>` +
+      subId +
       thumbsHtml +
       '<p class="sc-summary">' +
       "<strong>" +

--- a/src/lib/gallery-assets/index.css
+++ b/src/lib/gallery-assets/index.css
@@ -146,18 +146,20 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.sc-subid {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--fg-subtle);
-  margin-top: -8px;
-}
 
 .sc-summary {
   font-size: 13.5px;
   line-height: 1.45;
   color: var(--fg-muted);
   margin: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.sc-summary .sc-totals {
+  min-width: 0;
 }
 .sc-summary strong {
   color: var(--fg);
@@ -168,10 +170,24 @@
   color: var(--fg-faint);
   margin: 0 4px;
 }
-.sc-summary .breakdown {
-  color: var(--fg-subtle);
-  font-family: var(--font-mono);
+.sc-summary .breakdown-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  vertical-align: middle;
+  font-variant-numeric: tabular-nums;
+}
+.sc-summary .bi {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   font-size: 12px;
+}
+.sc-summary .bi svg {
+  display: block;
+}
+.sc-summary .bi .bn {
+  color: var(--fg-muted);
 }
 
 .sc-typebar {

--- a/src/lib/gallery-assets/index.css
+++ b/src/lib/gallery-assets/index.css
@@ -71,6 +71,71 @@
   justify-content: space-between;
   gap: 10px;
 }
+
+/* Fixed 25% slot width so sessions with <4 previews still pack left at a
+   consistent size — avoids one giant square for single-image sessions. */
+.sc-thumbs {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+}
+.sc-thumbs .thumb {
+  flex: 0 1 calc(25% - 3px);
+  aspect-ratio: 1;
+  background: var(--bg-overlay);
+  border-radius: var(--radius-2);
+  overflow: hidden;
+  display: block;
+  position: relative;
+}
+.sc-thumbs .thumb img,
+.sc-thumbs .thumb video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.sc-thumbs .thumb .audio-thumb {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 14% 8%;
+}
+.sc-thumbs .thumb .audio-thumb .bar {
+  flex: 1 1 0;
+  min-width: 0;
+  background: var(--fg-muted);
+  border-radius: 2px;
+  opacity: 0.55;
+}
+.sc-thumbs .thumb .play-badge {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.sc-thumbs .thumb .play-badge .disc {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  transition:
+    background 0.15s,
+    transform 0.15s;
+}
+.session-card:hover .sc-thumbs .thumb .play-badge .disc {
+  background: rgba(0, 0, 0, 0.65);
+  transform: scale(1.06);
+}
 .sc-id {
   font-family: var(--font-mono);
   font-size: 15px;

--- a/src/lib/gallery-assets/index.css
+++ b/src/lib/gallery-assets/index.css
@@ -95,6 +95,14 @@
   object-fit: cover;
   display: block;
 }
+.sc-thumbs .thumb .thumb-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.55;
+}
 .sc-thumbs .thumb .audio-thumb {
   position: absolute;
   inset: 0;
@@ -137,7 +145,7 @@
   transform: scale(1.06);
 }
 .sc-id {
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
   font-size: 15px;
   font-weight: 600;
   color: var(--fg);
@@ -145,6 +153,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.sc-id.mono {
+  font-family: var(--font-mono);
 }
 
 .sc-summary {

--- a/src/lib/gallery-assets/index.css
+++ b/src/lib/gallery-assets/index.css
@@ -142,6 +142,15 @@
   font-weight: 600;
   color: var(--fg);
   letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sc-subid {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-subtle);
+  margin-top: -8px;
 }
 
 .sc-summary {

--- a/src/lib/gallery-assets/session.client.js
+++ b/src/lib/gallery-assets/session.client.js
@@ -244,12 +244,7 @@
       const t = order[i];
       if (!counts[t]) continue;
       const c = (H.TYPE_INFO[t] || H.TYPE_INFO.other).color;
-      html +=
-        '<span class="b"><span class="sw" style="background:' +
-        c +
-        '"></span>' +
-        H.typeLabel(t, counts[t]) +
-        "</span>";
+      html += `<span class="b" style="color:${c}" title="${H.escapeHtml(H.typeLabel(t, counts[t]))}">${H.iconForKind(t, 12)}<span class="bn">${counts[t]}</span></span>`;
     }
     root.innerHTML = html;
   }

--- a/src/lib/gallery-assets/session.client.js
+++ b/src/lib/gallery-assets/session.client.js
@@ -140,6 +140,11 @@
 
   /* ---------- Header --------------------------------------------------- */
   function renderHeaderChips() {
+    // Promote the user-set label into the page title when present.
+    const titleEl = document.querySelector(".session-title");
+    if (titleEl && DATA.label) titleEl.textContent = DATA.label;
+    if (DATA.label) document.title = DATA.label;
+
     const chips = document.getElementById("header-chips");
     if (!chips) return;
     const parts = [];

--- a/src/lib/gallery-assets/shared.client.js
+++ b/src/lib/gallery-assets/shared.client.js
@@ -191,6 +191,25 @@
     '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="m10 14 11-11"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/></svg>';
   H.svgFile = () =>
     '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>';
+  H.svgImage = (s) => {
+    s = s || 13;
+    return `<svg width="${s}" height="${s}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>`;
+  };
+  H.svgVideo = (s) => {
+    s = s || 13;
+    return `<svg width="${s}" height="${s}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="14" height="12" rx="2"/><path d="m22 8-6 4 6 4z"/></svg>`;
+  };
+  H.svgAudio = (s) => {
+    s = s || 13;
+    return `<svg width="${s}" height="${s}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>`;
+  };
+  H.iconForKind = (kind, size) => {
+    if (kind === "image") return H.svgImage(size);
+    if (kind === "video") return H.svgVideo(size);
+    if (kind === "audio") return H.svgAudio(size);
+    if (kind === "model") return H.svgCube(size || 14);
+    return H.svgIconFile(size);
+  };
   H.svgIconFile = (s) => {
     s = s || 40;
     return (

--- a/src/lib/gallery-assets/styles.css
+++ b/src/lib/gallery-assets/styles.css
@@ -254,12 +254,14 @@ body {
 .stats .breakdown .b {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
 }
-.stats .breakdown .sw {
-  width: 7px;
-  height: 7px;
-  border-radius: 2px;
+.stats .breakdown .b svg {
+  display: block;
+}
+.stats .breakdown .b .bn {
+  color: var(--fg-muted);
+  font-size: 12px;
 }
 
 /* ---------- Scrollbar ---------------------------------------------------- */

--- a/src/lib/gallery-template.ts
+++ b/src/lib/gallery-template.ts
@@ -72,10 +72,10 @@ export interface SessionPayload {
   runs: RunRecord[];
 }
 
-// image/video render real media; audio shows a synthetic waveform.
-// 3d/other are skipped — no meaningful compact thumbnail.
+// image/video render real media; audio = synthetic waveform; 3d/other =
+// kind-icon placeholder. All counted toward the 4-slot cap (FIFO).
 export interface SessionPreview {
-  kind: "image" | "video" | "audio";
+  kind: "image" | "video" | "audio" | "model" | "other";
   file: string | null;
   url: string;
 }

--- a/src/lib/gallery-template.ts
+++ b/src/lib/gallery-template.ts
@@ -69,6 +69,14 @@ export interface SessionPayload {
   runs: RunRecord[];
 }
 
+// image/video render real media; audio shows a synthetic waveform.
+// 3d/other are skipped — no meaningful compact thumbnail.
+export interface SessionPreview {
+  kind: "image" | "video" | "audio";
+  file: string | null;
+  url: string;
+}
+
 export interface SessionSummary {
   session_id: string;
   agent: string | null;
@@ -79,6 +87,7 @@ export interface SessionSummary {
   asset_count: number;
   kind_counts: Record<AssetKind, number>;
   modalities: string[];
+  previews: SessionPreview[];
 }
 
 const HTML_ESCAPE_RE = /[&<>"']/g;

--- a/src/lib/gallery-template.ts
+++ b/src/lib/gallery-template.ts
@@ -66,6 +66,9 @@ export interface SessionPayload {
   cwd: string | null;
   started_at: number;
   updated_at: number;
+  // Optional user-set display name. Cosmetic only — the on-disk id stays
+  // anchored to the process-tree resolver so future runs still land here.
+  label?: string;
   runs: RunRecord[];
 }
 
@@ -79,6 +82,7 @@ export interface SessionPreview {
 
 export interface SessionSummary {
   session_id: string;
+  label: string | null;
   agent: string | null;
   agent_host: string | null;
   started_at: number;

--- a/src/lib/gallery.ts
+++ b/src/lib/gallery.ts
@@ -56,6 +56,7 @@ const DATA_FILE = "data.json";
 const PAGE_FILE = "index.html";
 const MAX_RUNS_PER_SESSION = 1000;
 const MAX_SESSION_PREVIEWS = 4;
+const MAX_LABEL_LENGTH = 80;
 const DEFAULT_RETENTION_DAYS = 60;
 
 export interface GalleryPaths {
@@ -274,6 +275,7 @@ function summarize(payload: SessionPayload): SessionSummary {
   }
   return {
     session_id: payload.session_id,
+    label: payload.label ?? null,
     agent: payload.agent,
     agent_host: payload.agent_host,
     started_at: payload.started_at,
@@ -423,6 +425,40 @@ export function recordRun(input: RecordRunInput): GalleryPaths | null {
     return null;
   }
 }
+
+export type RenameResult =
+  | { ok: true; label: string | null }
+  | { ok: false; reason: "not-found" | "too-long" | "write-failed" };
+
+// Sets or clears the cosmetic display label for a session. The on-disk id
+// stays anchored to the process-tree resolver so future runs still write
+// here — labels are an overlay, not a rename.
+export function renameSession(
+  sessionId: string,
+  rawLabel: string | null,
+): RenameResult {
+  const paths = galleryPaths(sessionId);
+  const payload = readSessionPayload(paths);
+  if (!payload) return { ok: false, reason: "not-found" };
+  const trimmed = rawLabel === null ? null : rawLabel.trim();
+  if (trimmed !== null && trimmed.length > MAX_LABEL_LENGTH) {
+    return { ok: false, reason: "too-long" };
+  }
+  if (trimmed === null || trimmed === "") {
+    delete payload.label;
+  } else {
+    payload.label = trimmed;
+  }
+  try {
+    writeSessionPayload(paths, payload);
+    regenerateRootIndexHtml();
+    return { ok: true, label: payload.label ?? null };
+  } catch {
+    return { ok: false, reason: "write-failed" };
+  }
+}
+
+export const LABEL_MAX_LENGTH = MAX_LABEL_LENGTH;
 
 export interface ClearOptions {
   sessionId?: string;

--- a/src/lib/gallery.ts
+++ b/src/lib/gallery.ts
@@ -55,6 +55,7 @@ function lastSessionPath(): string {
 const DATA_FILE = "data.json";
 const PAGE_FILE = "index.html";
 const MAX_RUNS_PER_SESSION = 1000;
+const MAX_SESSION_PREVIEWS = 4;
 const DEFAULT_RETENTION_DAYS = 60;
 
 export interface GalleryPaths {
@@ -257,11 +258,18 @@ function summarize(payload: SessionPayload): SessionSummary {
   };
   let assetCount = 0;
   const modalities = new Set<string>();
+  const previews: SessionSummary["previews"] = [];
   for (const r of payload.runs) {
     if (r.modality) modalities.add(r.modality);
     for (const f of r.files) {
       kindCounts[f.kind] = (kindCounts[f.kind] ?? 0) + 1;
       assetCount += 1;
+      if (
+        (f.kind === "image" || f.kind === "video" || f.kind === "audio") &&
+        previews.length < MAX_SESSION_PREVIEWS
+      ) {
+        previews.push({ kind: f.kind, file: f.path, url: f.url });
+      }
     }
   }
   return {
@@ -274,6 +282,7 @@ function summarize(payload: SessionPayload): SessionSummary {
     asset_count: assetCount,
     kind_counts: kindCounts,
     modalities: Array.from(modalities),
+    previews,
   };
 }
 

--- a/src/lib/gallery.ts
+++ b/src/lib/gallery.ts
@@ -265,10 +265,7 @@ function summarize(payload: SessionPayload): SessionSummary {
     for (const f of r.files) {
       kindCounts[f.kind] = (kindCounts[f.kind] ?? 0) + 1;
       assetCount += 1;
-      if (
-        (f.kind === "image" || f.kind === "video" || f.kind === "audio") &&
-        previews.length < MAX_SESSION_PREVIEWS
-      ) {
+      if (previews.length < MAX_SESSION_PREVIEWS) {
         previews.push({ kind: f.kind, file: f.path, url: f.url });
       }
     }


### PR DESCRIPTION
Follow-up to #11 (`feat/session-preview-gallery`). Layers UX and discoverability improvements on top of the per-session HTML gallery — no schema changes, no breaking changes to the structured JSON outputs that agents depend on.

## Summary

- `gallery` (bare) in pretty TTY mode now prints a single `→ Open: <url>` hint instead of the full field dump. `gallery info` (explicit) keeps the verbose field-dump-plus-rule-plus-open-hint output for developers. JSON / non-TTY mode is unchanged — same structured payload, agent-safe.
- Session cards on the all-sessions index now show up to **4 inline thumbnail previews**, FIFO across all kinds (image/video/audio/3d/other), capped at 4. Image and video previews load real media; audio renders a deterministic synthetic waveform; 3d/other show their kind-icon as a placeholder. Videos get a small dark-disc play badge overlay.
- Sessions can be **renamed** with a user-visible label that overlays the cryptic 12-char id, without changing the on-disk id (so future runs from the same agent process still land in the same directory).
- Visual breakdown — both the per-card "X images, Y videos…" row and the page-header global totals — now use kind-tinted SVG icons instead of color swatches + words.

## What's in

### CLI
- **`genmedia gallery` (bare)** — pretty TTY: single `→ Open: <url>` hint; JSON / non-TTY: full info payload (unchanged shape). The previous verbose key:value dump only appears now when `gallery info` is invoked explicitly.
- **`genmedia gallery info`** — full field-dump + horizontal rule + prominent `→ Open: <url>` footer in pretty TTY. JSON / non-TTY: full payload as before.
- **`genmedia gallery rename <target> --label "<name>"`** — set a display label on a session. `target` is `current` (default), `latest`, or an explicit `<session_id>`. `--clear` removes the label. Max 80 chars, trimmed. The on-disk session id is never touched — labels are a cosmetic overlay.
- **`genmedia gallery list`** (pretty mode) — shows the label next to the id when set, drops the redundant `agent_host` (e.g. `cursor`/`vscode`) for compactness, and adds a per-kind breakdown like `1 image, 2 videos, 1 audio`. When no agent can be resolved, the agent column is simply omitted rather than padded with "unknown agent".

### Index page (all-sessions)
- **Per-card thumbnail row** between the title row and the asset summary line. Up to 4 previews, FIFO across kinds, fixed `calc(25% - 3px)` slot width so 1–3 item sessions still look balanced.
- **Image thumbs**: standard `<img loading="lazy">`.
- **Video thumbs**: `<video preload="metadata" src="...#t=0.1">` — browsers stream only ~100–500 KB to paint the first frame as a static poster; no full-video download on hover.
- **Audio thumbs**: 18-bar synthetic waveform seeded off the URL, so the shape is deterministic across renders.
- **3D / other thumbs**: faded centered kind icon (cube / file) in the kind's brand color.
- **Play badge** overlay on video and audio thumbs: 28 px translucent dark disc + 16 px white play triangle, brightens slightly on card hover.
- **Card title** in proportional Public Sans when a label is set (raw session id still mono for legibility of hex), with the id preserved as a `title=` hover tooltip when a label is shown.
- **Right-aligned breakdown** on each card: `X assets across Y runs` on the left, kind icons (with counts) flex-pushed to the right. Falls to a second line on narrow cards via `flex-wrap`.
- **Search** matches against label as well as session id, agent, and host.

### Session page
- The user-set label is promoted into the page `<h1>` and the browser tab title when present.

### Page header (both index and per-session)
- Global asset totals also switched from `[color-swatch] 12 images` to icon-prefixed counts that match the per-card visual language.

## Storage

- `SessionPayload.label?: string` — additive optional field on `data.json`. `schema_version` stays `1`; no migration needed. Existing sessions written by #11 read back correctly and just have `null`/missing label, with the index falling back to the bare session id as title (verified end-to-end).
- `SessionSummary.label: string \| null` and `SessionSummary.previews: SessionPreview[]` exposed via `gallery list --json` and the index payload.
- `renameSession(sessionId, label)` in `src/lib/gallery.ts` — writes the label, regenerates the root index, returns a structured result (`{ ok, label }` or `{ ok: false, reason: "not-found" | "too-long" | "write-failed" }`).
- New constant `MAX_SESSION_PREVIEWS = 4`; `MAX_LABEL_LENGTH = 80` (exported as `LABEL_MAX_LENGTH`).
- Preview kind union: `"image" | "video" | "audio" | "model" | "other"`. Each preview carries both `file` (when downloaded) and `url`, picked client-side via `H.preferredSrc`.

## Backward compatibility

- `gallery list --json` adds `label` and `previews` fields. Both are additive — existing consumers continue to work.
- Sessions recorded by #11 (no label, no previews persisted in payload) re-summarize correctly: label = `null`, previews populated on read by `summarize()`.
- `genmedia gallery` JSON / non-TTY behavior unchanged; agents that scrape the structured payload are unaffected.
- `data.json` schema not bumped; no migration needed.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bun test src/commands/gallery/ src/lib/gallery.test.ts src/lib/session.test.ts src/lib/process-tree.test.ts` (36 pass, 0 fail; +new cases for `renameSession`, preview kind FIFO + cap, all-kinds inclusion)
- [x] `bun run dev gallery` in a real TTY → prints just the `→ Open: <url>` line
- [x] `bun run dev gallery info` in a real TTY → full field dump + rule + open footer
- [x] `bun run dev gallery --json` in any context → unchanged structured payload, no browser launch
- [x] `bun run dev gallery rename <id> --label "demo"` → JSON output `{ scope: "rename", target, session_id, label, url }`; subsequent `gallery list --json` shows `label`
- [x] `bun run dev gallery rename <id> --clear` → label removed from `data.json`; `gallery list --json` shows `label: null`
- [x] End-to-end smoke: generated images (flux/schnell), videos (kling 1.6 std), audio (elevenlabs sound-effects v2), and 3d (hunyuan-3d rapid) — all four kinds render correctly in the index card thumb row, with the icon mix capped at 4 chronologically
- [x] Reload `~/.genmedia/gallery/index.html` in browser — thumbnails render; video first-frame appears without full download; audio waveform is stable across reloads; play badge visible at hover
- [x] Pre-#11 sessions (no label, no `previews` in `data.json`) re-summarize to `label: null`, `previews: [...]` and render with id-as-title fallback; verified on `63d46bd815e8` written by the unmodified #11 code